### PR TITLE
feat: emit granular request progress events

### DIFF
--- a/docs/api-reference/fetch.mdx
+++ b/docs/api-reference/fetch.mdx
@@ -69,6 +69,14 @@ function fetch(input: string | URL | Request, init?: RequestInit): Promise<Respo
   When `true`, accepts invalid/self-signed certificates. **Use only in development.**
 </ParamField>
 
+<ParamField path="onRequestEvent" type="(event: RequestEvent) => void">
+  Optional callback for structured request lifecycle events emitted by the native layer. Use this to observe phases such as request start, response headers, and body download progress.
+</ParamField>
+
+<ParamField path="captureDiagnostics" type="boolean" default="false">
+  When `true`, captures a final diagnostics payload on the response where supported by the native layer. This can include timing, address, and TLS peer details.
+</ParamField>
+
 ## Response
 
 Returns a `Response` object with:
@@ -83,6 +91,7 @@ Returns a `Response` object with:
 - `bodyUsed`: `true` if body has been consumed
 - `contentLength`: content length from headers, or `null`
 - `cookies`: parsed response cookies as `Record<string, string | string[]>`
+- `diagnostics`: optional native diagnostics payload, or `null`
 
 ### Response methods
 
@@ -94,6 +103,24 @@ Returns a `Response` object with:
 - `clone()`: clone the response
 
 See [/concepts/compatibility-matrix](/concepts/compatibility-matrix) for detailed compatibility notes and intentional deviations.
+
+## Request lifecycle events
+
+When `onRequestEvent` is provided, `fetch()` emits structured events from the native bridge.
+
+| Event | Meaning |
+| --- | --- |
+| `request_start` | The request has started in the native layer. |
+| `request_sent` | Request headers/body have been handed off to the socket and the client is waiting for a response. |
+| `response_headers` | Response headers have been received. Includes `status` and optional `contentLength`. |
+| `body_progress` | Additional response body bytes were downloaded. Includes `downloadedBytes` and optional `contentLength`. |
+| `body_complete` | The response body finished downloading. |
+| `done` | The native request lifecycle completed successfully. |
+| `error` | The native request lifecycle failed. Includes `message` when available. |
+
+Each event includes a `timestamp`, and some events include `status`, `url`, `contentLength`, `downloadedBytes`, or `message`.
+
+For a full worked example, see [/guides/request-events](/guides/request-events).
 
 ## Convenience helpers
 
@@ -143,6 +170,28 @@ const response = await fetch('https://example.com/login', {
     password: 'pass',
   }),
 });
+```
+
+### Observe request events and diagnostics
+
+```typescript
+const response = await fetch('https://example.com/large-file', {
+  browser: 'chrome_142',
+  captureDiagnostics: true,
+  onRequestEvent(event) {
+    if (event.type === 'response_headers') {
+      console.log('status:', event.status);
+      console.log('content-length:', event.contentLength);
+    }
+
+    if (event.type === 'body_progress' && event.contentLength) {
+      const pct = ((event.downloadedBytes ?? 0) / event.contentLength) * 100;
+      console.log(`downloaded ${pct.toFixed(1)}%`);
+    }
+  },
+});
+
+console.log(response.diagnostics);
 ```
 
 ### With timeout and abort

--- a/docs/api-reference/sessions.mdx
+++ b/docs/api-reference/sessions.mdx
@@ -45,6 +45,10 @@ function createSession(options?: CreateSessionOptions): Promise<Session>
   Accept invalid certificates for all session requests. **Use only in development.**
 </ParamField>
 
+<ParamField path="captureDiagnostics" type="boolean" default="false">
+  Enable extra connection and TLS diagnostics for requests made through this session by default.
+</ParamField>
+
 ### Session object
 
 The returned `Session` object has:
@@ -61,6 +65,8 @@ const response = await session.fetch('https://example.com/api', {
 ```
 
 Per-request options override session defaults.
+
+`session.fetch()` also accepts request-scoped `onRequestEvent` and `captureDiagnostics` options from [`fetch()`](/api-reference/fetch). When diagnostics are enabled, inspect `response.diagnostics` on the returned response.
 
 #### session.websocket(url, options?)
 

--- a/docs/api-reference/transport.mdx
+++ b/docs/api-reference/transport.mdx
@@ -57,6 +57,10 @@ function createTransport(options?: CreateTransportOptions): Promise<Transport>
   Read timeout (ms).
 </ParamField>
 
+<ParamField path="captureDiagnostics" type="boolean" default="false">
+  Enable extra connection and TLS diagnostics for requests made through this transport by default.
+</ParamField>
+
 ## Using a transport with fetch()
 
 Pass the transport via `RequestInit.transport`.
@@ -81,6 +85,8 @@ try {
   await transport.close();
 }
 ```
+
+You can still pass per-request `onRequestEvent` callbacks when using a transport. If `captureDiagnostics` is enabled on the transport, returned responses expose `response.diagnostics` without having to repeat the flag on every request.
 
 ### Important: request options that become invalid
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,7 +46,7 @@
           },
           {
             "group": "Guides",
-            "pages": ["guides/proxy-usage", "guides/streaming", "guides/websockets"]
+            "pages": ["guides/proxy-usage", "guides/streaming", "guides/request-events", "guides/websockets"]
           }
         ]
       },

--- a/docs/guides/request-events.mdx
+++ b/docs/guides/request-events.mdx
@@ -1,0 +1,131 @@
+---
+title: Request Events and Diagnostics
+description: "Observe native request lifecycle events and inspect optional diagnostics payloads."
+---
+
+## Overview
+
+`wreq-js` can emit structured native request lifecycle events through `onRequestEvent` and can attach an optional diagnostics payload to the final `Response` when `captureDiagnostics` is enabled.
+
+Use this when you need to:
+
+- render transport-phase progress such as connecting, waiting, and loading
+- observe native download progress without consuming `response.body` first
+- capture timing, address, or TLS peer details for debugging
+
+## Enable request events
+
+```typescript
+import { fetch } from 'wreq-js';
+
+const response = await fetch('https://example.com/file.zip', {
+  browser: 'chrome_142',
+  onRequestEvent(event) {
+    console.log(event.type, event);
+  },
+});
+
+console.log(response.status);
+```
+
+## Event types
+
+| Event | Meaning | Common fields |
+| --- | --- | --- |
+| `request_start` | Request has started in the native layer. | `timestamp`, `url` |
+| `request_sent` | Request has been sent and the client is waiting for a response. | `timestamp`, `url` |
+| `response_headers` | Response headers have arrived. | `timestamp`, `status`, `contentLength`, `url` |
+| `body_progress` | More response bytes were downloaded. | `timestamp`, `downloadedBytes`, `contentLength`, `url` |
+| `body_complete` | Response body download finished. | `timestamp`, `contentLength`, `url` |
+| `done` | Native request lifecycle completed successfully. | `timestamp`, `status`, `url` |
+| `error` | Native request lifecycle failed. | `timestamp`, `message`, `url` |
+
+## Progress example
+
+```typescript
+const response = await fetch('https://example.com/file.zip', {
+  browser: 'chrome_142',
+  onRequestEvent(event) {
+    switch (event.type) {
+      case 'request_start':
+        console.log('connecting');
+        break;
+      case 'request_sent':
+        console.log('waiting');
+        break;
+      case 'response_headers':
+        console.log('status:', event.status);
+        break;
+      case 'body_progress':
+        if (event.contentLength) {
+          const downloaded = event.downloadedBytes ?? 0;
+          const pct = (downloaded / event.contentLength) * 100;
+          console.log(`loading ${pct.toFixed(1)}%`);
+        }
+        break;
+      case 'body_complete':
+        console.log('download complete');
+        break;
+      case 'error':
+        console.error(event.message);
+        break;
+    }
+  },
+});
+
+console.log(await response.arrayBuffer());
+```
+
+## Enable diagnostics
+
+```typescript
+const response = await fetch('https://example.com', {
+  browser: 'chrome_142',
+  captureDiagnostics: true,
+});
+
+console.log(response.diagnostics);
+```
+
+When available, `response.diagnostics` may include:
+
+- `totalDurationMs`
+- `headersDurationMs`
+- `status`
+- `localAddr`
+- `remoteAddr`
+- `tlsPeerCertificatePresent`
+- `tlsPeerCertificateChainLength`
+
+## Session and transport defaults
+
+You can enable diagnostics by default on a session or transport:
+
+```typescript
+import { createSession, createTransport } from 'wreq-js';
+
+const session = await createSession({
+  browser: 'chrome_142',
+  captureDiagnostics: true,
+});
+
+const transport = await createTransport({
+  proxy: 'http://proxy.example.com:8080',
+  captureDiagnostics: true,
+});
+```
+
+`onRequestEvent` remains a per-request callback, so you still pass it to `fetch()` or `session.fetch()` for the specific requests you want to observe.
+
+## Notes
+
+- Request events come from the native layer and reflect transport lifecycle phases, not application-level parsing.
+- `body_progress` is emitted during native download. You can still consume `response.body`, `response.text()`, `response.json()`, and the other body helpers normally.
+- Diagnostics are optional and may vary by platform or native support level.
+
+## Related
+
+- [`fetch()`](/api-reference/fetch)
+- [`Sessions`](/api-reference/sessions)
+- [`Transport`](/api-reference/transport)
+- [`Streaming Responses`](/guides/streaming)

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -74,7 +74,7 @@ while (true) {
 
 ## Download with progress
 
-Track download progress:
+Track download progress from the response stream itself:
 
 ```typescript
 const response = await fetch('https://example.com/file.zip', {
@@ -111,6 +111,44 @@ for (const chunk of chunks) {
   position += chunk.byteLength;
 }
 ```
+
+## Transport-level request progress
+
+If you want progress before you start consuming `response.body`, use `onRequestEvent`.
+This gives you visibility into request start, headers, and native body download progress.
+
+```typescript
+const response = await fetch('https://example.com/file.zip', {
+  browser: 'chrome_142',
+  onRequestEvent(event) {
+    switch (event.type) {
+      case 'request_start':
+        console.log('connecting');
+        break;
+      case 'request_sent':
+        console.log('waiting for response');
+        break;
+      case 'response_headers':
+        console.log('status:', event.status);
+        console.log('length:', event.contentLength);
+        break;
+      case 'body_progress':
+        if (event.contentLength) {
+          const pct = ((event.downloadedBytes ?? 0) / event.contentLength) * 100;
+          console.log(`downloaded ${pct.toFixed(1)}%`);
+        }
+        break;
+      case 'body_complete':
+        console.log('download complete');
+        break;
+    }
+  },
+});
+
+console.log(await response.arrayBuffer());
+```
+
+For more detail on event payloads and diagnostics, see [/guides/request-events](/guides/request-events).
 
 ## Server-Sent Events (SSE)
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -8,13 +8,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use wreq::cookie::Jar;
 use wreq::header::OrigHeaderMap;
-use wreq::tls::CertStore;
+use wreq::tls::{CertStore, TlsInfo};
 use wreq::{Client as HttpClient, Method, Proxy, redirect};
 
 use crate::custom_emulation::resolve_emulation;
@@ -69,7 +69,55 @@ impl RedirectMode {
     }
 }
 
+pub type RequestEventSink = Arc<dyn Fn(RequestEvent) + Send + Sync>;
+
 #[derive(Debug, Clone)]
+pub enum RequestEvent {
+    RequestStart {
+        timestamp_ms: u64,
+    },
+    RequestSent {
+        timestamp_ms: u64,
+    },
+    ResponseHeaders {
+        timestamp_ms: u64,
+        status: u16,
+        url: String,
+        content_length: Option<u64>,
+    },
+    BodyProgress {
+        timestamp_ms: u64,
+        downloaded_bytes: u64,
+        content_length: Option<u64>,
+    },
+    BodyComplete {
+        timestamp_ms: u64,
+        downloaded_bytes: u64,
+        content_length: Option<u64>,
+    },
+    Done {
+        timestamp_ms: u64,
+        status: u16,
+        url: String,
+    },
+    Error {
+        timestamp_ms: u64,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestDiagnostics {
+    pub total_duration_ms: Option<u64>,
+    pub headers_duration_ms: Option<u64>,
+    pub status: Option<u16>,
+    pub local_addr: Option<String>,
+    pub remote_addr: Option<String>,
+    pub tls_peer_certificate_present: bool,
+    pub tls_peer_certificate_chain_length: Option<usize>,
+}
+
+#[derive(Clone)]
 pub struct RequestOptions {
     pub url: String,
     pub browser: Option<BrowserEmulation>,
@@ -93,6 +141,8 @@ pub struct RequestOptions {
     pub connect_timeout: Option<u64>,
     pub read_timeout: Option<u64>,
     pub compress: bool,
+    pub capture_diagnostics: bool,
+    pub event_sink: Option<RequestEventSink>,
 }
 
 #[derive(Debug, Clone)]
@@ -104,6 +154,7 @@ pub struct Response {
     pub cookies: Vec<(String, String)>,
     pub url: String,
     pub content_length: Option<u64>,
+    pub diagnostics: Option<RequestDiagnostics>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -116,6 +167,7 @@ struct SessionConfig {
     trust_store: TrustStoreMode,
     connect_timeout: Option<Duration>,
     read_timeout: Option<Duration>,
+    capture_diagnostics: bool,
 }
 
 impl SessionConfig {
@@ -130,6 +182,7 @@ impl SessionConfig {
             trust_store: options.trust_store,
             connect_timeout: options.connect_timeout.map(Duration::from_millis),
             read_timeout: options.read_timeout.map(Duration::from_millis),
+            capture_diagnostics: options.capture_diagnostics,
         }
     }
 }
@@ -147,6 +200,7 @@ struct TransportConfig {
     pool_max_size: Option<u32>,
     connect_timeout: Option<Duration>,
     read_timeout: Option<Duration>,
+    capture_diagnostics: bool,
 }
 
 impl TransportConfig {
@@ -164,6 +218,7 @@ impl TransportConfig {
             pool_max_size: options.pool_max_size,
             connect_timeout: options.connect_timeout.map(Duration::from_millis),
             read_timeout: options.read_timeout.map(Duration::from_millis),
+            capture_diagnostics: options.capture_diagnostics,
         }
     }
 
@@ -180,6 +235,7 @@ impl TransportConfig {
         pool_max_size: Option<u32>,
         connect_timeout: Option<u64>,
         read_timeout: Option<u64>,
+        capture_diagnostics: bool,
     ) -> Self {
         Self {
             browser,
@@ -193,6 +249,7 @@ impl TransportConfig {
             pool_max_size,
             connect_timeout: connect_timeout.map(Duration::from_millis),
             read_timeout: read_timeout.map(Duration::from_millis),
+            capture_diagnostics,
         }
     }
 }
@@ -229,12 +286,54 @@ struct EphemeralClientManager {
 
 pub type ResponseBodyStream = Pin<Box<dyn Stream<Item = wreq::Result<Bytes>> + Send>>;
 
+#[derive(Clone)]
+struct BodyEventState {
+    sink: RequestEventSink,
+    content_length: Option<u64>,
+    downloaded_bytes: Arc<AtomicU64>,
+    status: u16,
+    url: String,
+}
+
 static BODY_STREAMS: LazyLock<Cache<u64, Arc<Mutex<ResponseBodyStream>>>> = LazyLock::new(|| {
     Cache::builder()
         .time_to_idle(Duration::from_secs(300))
         .build()
 });
+static BODY_EVENT_STATES: LazyLock<DashMap<u64, BodyEventState>> = LazyLock::new(DashMap::new);
 static NEXT_BODY_HANDLE: AtomicU64 = AtomicU64::new(1);
+
+fn emit_request_event(sink: &Option<RequestEventSink>, event: RequestEvent) {
+    if let Some(sink) = sink {
+        sink(event);
+    }
+}
+
+fn emit_body_progress(state: &BodyEventState, chunk_len: u64) {
+    let downloaded = state
+        .downloaded_bytes
+        .fetch_add(chunk_len, Ordering::Relaxed)
+        + chunk_len;
+    (state.sink)(RequestEvent::BodyProgress {
+        timestamp_ms: 0,
+        downloaded_bytes: downloaded,
+        content_length: state.content_length,
+    });
+}
+
+fn emit_body_complete(state: &BodyEventState) {
+    let downloaded = state.downloaded_bytes.load(Ordering::Relaxed);
+    (state.sink)(RequestEvent::BodyComplete {
+        timestamp_ms: 0,
+        downloaded_bytes: downloaded,
+        content_length: state.content_length,
+    });
+    (state.sink)(RequestEvent::Done {
+        timestamp_ms: 0,
+        status: state.status,
+        url: state.url.clone(),
+    });
+}
 
 fn next_body_handle() -> u64 {
     NEXT_BODY_HANDLE.fetch_add(1, Ordering::Relaxed)
@@ -282,13 +381,27 @@ pub async fn read_body_chunk(handle: u64) -> Result<Option<Bytes>> {
     let next = guard.next().await;
 
     match next {
-        Some(Ok(bytes)) => Ok(Some(bytes)),
+        Some(Ok(bytes)) => {
+            if let Some(state) = BODY_EVENT_STATES.get(&handle) {
+                emit_body_progress(&state, bytes.len() as u64);
+            }
+            Ok(Some(bytes))
+        }
         Some(Err(err)) => {
             BODY_STREAMS.invalidate(&handle);
+            if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
+                (state.sink)(RequestEvent::Error {
+                    timestamp_ms: 0,
+                    message: format!("{:#}", err),
+                });
+            }
             Err(err.into())
         }
         None => {
             BODY_STREAMS.invalidate(&handle);
+            if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
+                emit_body_complete(&state);
+            }
             Ok(None)
         }
     }
@@ -307,7 +420,14 @@ pub async fn read_body_all(handle: u64) -> Result<Bytes> {
     while let Some(result) = guard.next().await {
         let bytes = result?;
         total_len += bytes.len();
+        if let Some(state) = BODY_EVENT_STATES.get(&handle) {
+            emit_body_progress(&state, bytes.len() as u64);
+        }
         chunks.push(bytes);
+    }
+
+    if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
+        emit_body_complete(&state);
     }
 
     // Fast path: single chunk or empty
@@ -328,6 +448,7 @@ pub async fn read_body_all(handle: u64) -> Result<Bytes> {
 
 pub fn drop_body_stream(handle: u64) {
     BODY_STREAMS.invalidate(&handle);
+    BODY_EVENT_STATES.remove(&handle);
 }
 
 impl TransportManager {
@@ -458,8 +579,17 @@ async fn make_request_inner(
         redirect,
         disable_default_headers,
         compress,
+        capture_diagnostics,
+        event_sink,
         ..
     } = options;
+    let start = Instant::now();
+    emit_request_event(
+        &event_sink,
+        RequestEvent::RequestStart {
+            timestamp_ms: 0,
+        },
+    );
 
     // Methods are already normalized to uppercase in JS; default to GET when empty.
     let method = if method.is_empty() {
@@ -522,6 +652,13 @@ async fn make_request_inner(
 
     request = request.cookie_provider(cookie_jar);
 
+    emit_request_event(
+        &event_sink,
+        RequestEvent::RequestSent {
+            timestamp_ms: start.elapsed().as_millis() as u64,
+        },
+    );
+
     // Execute request
     let response = request
         .send()
@@ -548,6 +685,35 @@ async fn make_request_inner(
         .collect();
 
     let mut content_length = response.content_length();
+    emit_request_event(
+        &event_sink,
+        RequestEvent::ResponseHeaders {
+            timestamp_ms: start.elapsed().as_millis() as u64,
+            status,
+            url: final_url.clone(),
+            content_length,
+        },
+    );
+
+    let diagnostics = if capture_diagnostics {
+        let tls_info = response.extensions().get::<TlsInfo>();
+        Some(RequestDiagnostics {
+            total_duration_ms: None,
+            headers_duration_ms: Some(start.elapsed().as_millis() as u64),
+            status: Some(status),
+            local_addr: response.local_addr().map(|addr| addr.to_string()),
+            remote_addr: response.remote_addr().map(|addr| addr.to_string()),
+            tls_peer_certificate_present: tls_info
+                .and_then(|info| info.peer_certificate())
+                .is_some(),
+            tls_peer_certificate_chain_length: tls_info
+                .and_then(|info| info.peer_certificate_chain())
+                .map(|chain| chain.count()),
+        })
+    } else {
+        None
+    };
+
     let allows_body = response_allows_body(status, method.as_ref());
 
     let (body_handle, body_bytes) = if allows_body {
@@ -558,14 +724,56 @@ async fn make_request_inner(
         if inline_eligible {
             let bytes = response.bytes().await?;
             content_length = Some(bytes.len() as u64);
+            if let Some(sink) = event_sink.as_ref() {
+                sink(RequestEvent::BodyProgress {
+                    timestamp_ms: start.elapsed().as_millis() as u64,
+                    downloaded_bytes: bytes.len() as u64,
+                    content_length,
+                });
+                sink(RequestEvent::BodyComplete {
+                    timestamp_ms: start.elapsed().as_millis() as u64,
+                    downloaded_bytes: bytes.len() as u64,
+                    content_length,
+                });
+                sink(RequestEvent::Done {
+                    timestamp_ms: start.elapsed().as_millis() as u64,
+                    status,
+                    url: final_url.clone(),
+                });
+            }
             (None, Some(bytes))
         } else {
             let stream: ResponseBodyStream = Box::pin(response.bytes_stream());
-            (Some(store_body_stream(stream)), None)
+            let handle = store_body_stream(stream);
+            if let Some(sink) = event_sink.as_ref() {
+                BODY_EVENT_STATES.insert(
+                    handle,
+                    BodyEventState {
+                        sink: sink.clone(),
+                        content_length,
+                        downloaded_bytes: Arc::new(AtomicU64::new(0)),
+                        status,
+                        url: final_url.clone(),
+                    },
+                );
+            }
+            (Some(handle), None)
         }
     } else {
+        if let Some(sink) = event_sink.as_ref() {
+            sink(RequestEvent::Done {
+                timestamp_ms: start.elapsed().as_millis() as u64,
+                status,
+                url: final_url.clone(),
+            });
+        }
         (None, None)
     };
+
+    let diagnostics = diagnostics.map(|mut diagnostics| {
+        diagnostics.total_duration_ms = Some(start.elapsed().as_millis() as u64);
+        diagnostics
+    });
 
     Ok(Response {
         status,
@@ -575,6 +783,7 @@ async fn make_request_inner(
         cookies,
         url: final_url,
         content_length,
+        diagnostics,
     })
 }
 
@@ -620,6 +829,10 @@ fn build_client(config: &TransportConfig) -> Result<ResolvedClient> {
         client_builder = client_builder.read_timeout(read_timeout);
     }
 
+    if config.capture_diagnostics {
+        client_builder = client_builder.tls_info(true);
+    }
+
     let http_client = client_builder
         .build()
         .context("Failed to build HTTP client")?;
@@ -659,6 +872,10 @@ fn build_ephemeral_client(config: &SessionConfig) -> Result<ResolvedClient> {
 
     if let Some(read_timeout) = config.read_timeout {
         client_builder = client_builder.read_timeout(read_timeout);
+    }
+
+    if config.capture_diagnostics {
+        client_builder = client_builder.tls_info(true);
     }
 
     let http_client = client_builder
@@ -705,6 +922,7 @@ pub fn create_managed_transport(
     pool_max_size: Option<u32>,
     connect_timeout: Option<u64>,
     read_timeout: Option<u64>,
+    capture_diagnostics: bool,
 ) -> Result<String> {
     let config = TransportConfig::new(
         browser,
@@ -718,6 +936,7 @@ pub fn create_managed_transport(
         pool_max_size,
         connect_timeout,
         read_timeout,
+        capture_diagnostics,
     );
     TRANSPORT_MANAGER.create_transport(config)
 }
@@ -773,6 +992,8 @@ mod tests {
             connect_timeout: None,
             read_timeout: None,
             compress: true,
+            capture_diagnostics: false,
+            event_sink: None,
         }
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -738,7 +738,9 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
         capture_diagnostics_opt,
     ) = if let Some(value) = options_value {
         if value.is_a::<JsUndefined, _>(&mut cx) || value.is_a::<JsNull, _>(&mut cx) {
-(None, None, None, None, None, None, None, None, None, None, None)
+            (
+                None, None, None, None, None, None, None, None, None, None, None, None,
+            )
         } else {
             let obj = value.downcast_or_throw::<JsObject, _>(&mut cx)?;
             let browser = obj
@@ -806,7 +808,9 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
             )
         }
     } else {
-(None, None, None, None, None, None, None, None, None, None, None)
+        (
+            None, None, None, None, None, None, None, None, None, None, None, None,
+        )
     };
 
     let browser = browser_opt.as_deref().map(parse_emulation);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,11 +5,11 @@ mod websocket;
 
 use anyhow::anyhow;
 use client::{
-    HTTP_RUNTIME, RedirectMode, RequestOptions, Response, clear_managed_session,
-    create_managed_session, create_managed_transport, drop_body_stream, drop_managed_session,
-    drop_managed_transport, generate_session_id, get_session_cookies, make_request,
-    read_body_all as native_read_body_all, read_body_chunk as native_read_body_chunk,
-    set_session_cookie, TrustStoreMode,
+    HTTP_RUNTIME, RedirectMode, RequestEvent, RequestOptions, Response,
+    clear_managed_session, create_managed_session, create_managed_transport, drop_body_stream,
+    drop_managed_session, drop_managed_transport, generate_session_id, get_session_cookies,
+    make_request, read_body_all as native_read_body_all,
+    read_body_chunk as native_read_body_chunk, set_session_cookie, TrustStoreMode,
 };
 use dashmap::DashMap;
 use futures_util::StreamExt;
@@ -166,6 +166,7 @@ fn parse_headers_from_value(
 fn js_object_to_request_options(
     cx: &mut FunctionContext,
     obj: Handle<JsObject>,
+    event_sink: Option<client::RequestEventSink>,
 ) -> NeonResult<RequestOptions> {
     // Get URL (required)
     let url: Handle<JsString> = obj.get(cx, "url")?;
@@ -288,6 +289,12 @@ fn js_object_to_request_options(
         .map(|v| v.value(cx))
         .filter(|v| !v.trim().is_empty());
 
+    let capture_diagnostics = obj
+        .get_opt(cx, "captureDiagnostics")?
+        .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(cx).ok())
+        .map(|v| v.value(cx))
+        .unwrap_or(false);
+
     let pool_idle_timeout = obj
         .get_opt(cx, "poolIdleTimeout")?
         .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
@@ -336,6 +343,8 @@ fn js_object_to_request_options(
         connect_timeout,
         read_timeout,
         compress,
+        capture_diagnostics,
+        event_sink,
     })
 }
 
@@ -411,6 +420,155 @@ fn response_to_js_object<'a, C: Context<'a>>(
         obj.set(cx, "contentLength", null_value)?;
     }
 
+    // Diagnostics payload (if present)
+    if let Some(diagnostics) = response.diagnostics {
+        let diagnostics_obj = cx.empty_object();
+        if let Some(total_duration_ms) = diagnostics.total_duration_ms {
+            let value = cx.number(total_duration_ms as f64);
+            diagnostics_obj.set(cx, "totalDurationMs", value)?;
+        }
+        if let Some(headers_duration_ms) = diagnostics.headers_duration_ms {
+            let value = cx.number(headers_duration_ms as f64);
+            diagnostics_obj.set(cx, "headersDurationMs", value)?;
+        }
+        if let Some(status) = diagnostics.status {
+            let value = cx.number(status as f64);
+            diagnostics_obj.set(cx, "status", value)?;
+        }
+        if let Some(local_addr) = diagnostics.local_addr {
+            let value = cx.string(local_addr);
+            diagnostics_obj.set(cx, "localAddr", value)?;
+        }
+        if let Some(remote_addr) = diagnostics.remote_addr {
+            let value = cx.string(remote_addr);
+            diagnostics_obj.set(cx, "remoteAddr", value)?;
+        }
+        let tls_present = cx.boolean(diagnostics.tls_peer_certificate_present);
+        diagnostics_obj.set(cx, "tlsPeerCertificatePresent", tls_present)?;
+        if let Some(chain_length) = diagnostics.tls_peer_certificate_chain_length {
+            let value = cx.number(chain_length as f64);
+            diagnostics_obj.set(cx, "tlsPeerCertificateChainLength", value)?;
+        }
+        obj.set(cx, "diagnostics", diagnostics_obj)?;
+    } else {
+        let null_value = cx.null();
+        obj.set(cx, "diagnostics", null_value)?;
+    }
+
+    Ok(obj)
+}
+
+fn request_event_to_js_object<'a, C: Context<'a>>(
+    cx: &mut C,
+    event: RequestEvent,
+) -> JsResult<'a, JsObject> {
+    let obj = cx.empty_object();
+
+    match event {
+        RequestEvent::RequestStart { timestamp_ms } => {
+            let event_type = cx.string("request_start");
+            let timestamp = cx.number(timestamp_ms as f64);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+        }
+        RequestEvent::RequestSent { timestamp_ms } => {
+            let event_type = cx.string("request_sent");
+            let timestamp = cx.number(timestamp_ms as f64);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+        }
+        RequestEvent::ResponseHeaders {
+            timestamp_ms,
+            status,
+            url,
+            content_length,
+        } => {
+            let event_type = cx.string("response_headers");
+            let timestamp = cx.number(timestamp_ms as f64);
+            let status_value = cx.number(status as f64);
+            let url_value = cx.string(url);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+            obj.set(cx, "status", status_value)?;
+            obj.set(cx, "url", url_value)?;
+            match content_length {
+                Some(value) => {
+                    let content_length_value = cx.number(value as f64);
+                    obj.set(cx, "contentLength", content_length_value)?;
+                }
+                None => {
+                    let null_value = cx.null();
+                    obj.set(cx, "contentLength", null_value)?;
+                }
+            };
+        }
+        RequestEvent::BodyProgress {
+            timestamp_ms,
+            downloaded_bytes,
+            content_length,
+        } => {
+            let event_type = cx.string("body_progress");
+            let timestamp = cx.number(timestamp_ms as f64);
+            let downloaded_bytes_value = cx.number(downloaded_bytes as f64);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+            obj.set(cx, "downloadedBytes", downloaded_bytes_value)?;
+            match content_length {
+                Some(value) => {
+                    let content_length_value = cx.number(value as f64);
+                    obj.set(cx, "contentLength", content_length_value)?;
+                }
+                None => {
+                    let null_value = cx.null();
+                    obj.set(cx, "contentLength", null_value)?;
+                }
+            };
+        }
+        RequestEvent::BodyComplete {
+            timestamp_ms,
+            downloaded_bytes,
+            content_length,
+        } => {
+            let event_type = cx.string("body_complete");
+            let timestamp = cx.number(timestamp_ms as f64);
+            let downloaded_bytes_value = cx.number(downloaded_bytes as f64);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+            obj.set(cx, "downloadedBytes", downloaded_bytes_value)?;
+            match content_length {
+                Some(value) => {
+                    let content_length_value = cx.number(value as f64);
+                    obj.set(cx, "contentLength", content_length_value)?;
+                }
+                None => {
+                    let null_value = cx.null();
+                    obj.set(cx, "contentLength", null_value)?;
+                }
+            };
+        }
+        RequestEvent::Done { timestamp_ms, status, url } => {
+            let event_type = cx.string("done");
+            let timestamp = cx.number(timestamp_ms as f64);
+            let status_value = cx.number(status as f64);
+            let url_value = cx.string(url);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+            obj.set(cx, "status", status_value)?;
+            obj.set(cx, "url", url_value)?;
+        }
+        RequestEvent::Error {
+            timestamp_ms,
+            message,
+        } => {
+            let event_type = cx.string("error");
+            let timestamp = cx.number(timestamp_ms as f64);
+            let message_value = cx.string(message);
+            obj.set(cx, "type", event_type)?;
+            obj.set(cx, "timestamp", timestamp)?;
+            obj.set(cx, "message", message_value)?;
+        }
+    }
+
     Ok(obj)
 }
 
@@ -425,16 +583,41 @@ fn request(mut cx: FunctionContext) -> JsResult<JsPromise> {
         .map(|b| b.value(&mut cx))
         .unwrap_or(true);
 
-    // Convert JS object to Rust struct
-    let options = js_object_to_request_options(&mut cx, options_obj)?;
-
-    // Create a promise
-    let (deferred, promise) = cx.promise();
     let settle_channel = cx.channel();
+    let event_sink = options_obj
+        .get_opt::<JsFunction, _, _>(&mut cx, "onRequestEvent")?
+        .map(|callback| {
+            let callback = Arc::new(callback.root(&mut cx));
+            let channel = settle_channel.clone();
+            Arc::new(move |event: RequestEvent| {
+                let callback = callback.clone();
+                channel.send(move |mut cx| {
+                    let cb = callback.to_inner(&mut cx);
+                    let this = cx.undefined();
+                    let event_obj = request_event_to_js_object(&mut cx, event)?;
+                    cb.call(&mut cx, this, vec![event_obj.upcast()])?;
+                    Ok(())
+                });
+            }) as client::RequestEventSink
+        });
+
+    // Convert JS object to Rust struct
+    let options = js_object_to_request_options(&mut cx, options_obj, event_sink)?;
+    let error_event_sink = options.event_sink.clone();
+
+    let (deferred, promise) = cx.promise();
 
     if !cancellable {
         HTTP_RUNTIME.spawn(async move {
             let result = make_request(options).await;
+            if let Err(ref e) = result {
+                if let Some(sink) = error_event_sink.as_ref() {
+                    sink(RequestEvent::Error {
+                        timestamp_ms: 0,
+                        message: format!("{:#}", e),
+                    });
+                }
+            }
 
             // Send result back to JS
             deferred.settle_with(&settle_channel, move |mut cx| match result {
@@ -458,6 +641,15 @@ fn request(mut cx: FunctionContext) -> JsResult<JsPromise> {
             _ = token.cancelled() => Err(anyhow!("Request aborted")),
             res = make_request(options) => res,
         };
+
+        if let Err(ref e) = result {
+            if let Some(sink) = error_event_sink.as_ref() {
+                sink(RequestEvent::Error {
+                    timestamp_ms: 0,
+                    message: format!("{:#}", e),
+                });
+            }
+        }
 
         REQUEST_CANCELLATIONS.remove(&request_id);
 
@@ -543,11 +735,10 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
         pool_max_size_opt,
         connect_timeout_opt,
         read_timeout_opt,
+        capture_diagnostics_opt,
     ) = if let Some(value) = options_value {
         if value.is_a::<JsUndefined, _>(&mut cx) || value.is_a::<JsNull, _>(&mut cx) {
-            (
-                None, None, None, None, None, None, None, None, None, None, None,
-            )
+(None, None, None, None, None, None, None, None, None, None, None)
         } else {
             let obj = value.downcast_or_throw::<JsObject, _>(&mut cx)?;
             let browser = obj
@@ -594,6 +785,10 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
                 .get_opt(&mut cx, "readTimeout")?
                 .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(&mut cx).ok())
                 .map(|v| v.value(&mut cx) as u64);
+            let capture_diagnostics = obj
+                .get_opt(&mut cx, "captureDiagnostics")?
+                .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(&mut cx).ok())
+                .map(|v| v.value(&mut cx));
 
             (
                 browser,
@@ -607,12 +802,11 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
                 pool_max_size,
                 connect_timeout,
                 read_timeout,
+                capture_diagnostics,
             )
         }
     } else {
-        (
-            None, None, None, None, None, None, None, None, None, None, None,
-        )
+(None, None, None, None, None, None, None, None, None, None, None)
     };
 
     let browser = browser_opt.as_deref().map(parse_emulation);
@@ -622,6 +816,7 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
         .as_deref()
         .map(parse_trust_store_mode)
         .unwrap_or_default();
+    let capture_diagnostics = capture_diagnostics_opt.unwrap_or(false);
 
     match create_managed_transport(
         browser,
@@ -635,6 +830,7 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
         pool_max_size_opt,
         connect_timeout_opt,
         read_timeout_opt,
+        capture_diagnostics,
     ) {
         Ok(id) => Ok(cx.string(id)),
         Err(e) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,35 @@ export interface WebSocketCloseEvent {
  * };
  * ```
  */
+export type RequestEventType =
+  | "request_start"
+  | "request_sent"
+  | "response_headers"
+  | "body_progress"
+  | "body_complete"
+  | "done"
+  | "error";
+
+export interface RequestEvent {
+  type: RequestEventType;
+  timestamp: number;
+  status?: number;
+  url?: string;
+  contentLength?: number | null;
+  downloadedBytes?: number;
+  message?: string;
+}
+
+export interface RequestDiagnostics {
+  totalDurationMs?: number;
+  headersDurationMs?: number;
+  status?: number;
+  localAddr?: string;
+  remoteAddr?: string;
+  tlsPeerCertificatePresent?: boolean;
+  tlsPeerCertificateChainLength?: number;
+}
+
 export interface RequestInit {
   /**
    * A string to set request's method.
@@ -386,6 +415,17 @@ export interface RequestInit {
    * @default true
    */
   compress?: boolean;
+
+  /**
+   * Optional callback for structured request lifecycle events emitted by the
+   * native bridge.
+   */
+  onRequestEvent?: (event: RequestEvent) => void;
+
+  /**
+   * Capture a final diagnostics payload where supported by the native layer.
+   */
+  captureDiagnostics?: boolean;
 }
 
 /**
@@ -446,6 +486,11 @@ export interface CreateSessionOptions {
    * @default "combined"
    */
   trustStore?: TrustStoreMode;
+
+  /**
+   * Enable extra connection/TLS diagnostics for requests made through this session.
+   */
+  captureDiagnostics?: boolean;
 }
 
 /**
@@ -507,6 +552,11 @@ export interface CreateTransportOptions {
    * Read timeout (ms).
    */
   readTimeout?: number;
+
+  /**
+   * Enable extra connection/TLS diagnostics for requests made through this transport.
+   */
+  captureDiagnostics?: boolean;
 }
 
 /**
@@ -654,6 +704,17 @@ export interface RequestOptions {
    * @default "combined"
    */
   trustStore?: TrustStoreMode;
+
+  /**
+   * Optional callback for structured request lifecycle events emitted by the
+   * native bridge.
+   */
+  onRequestEvent?: (event: RequestEvent) => void;
+
+  /**
+   * Capture a final diagnostics payload where supported by the native layer.
+   */
+  captureDiagnostics?: boolean;
 }
 
 /**
@@ -702,6 +763,11 @@ export interface NativeResponse {
    * If no redirects occurred, this will match the original request URL.
    */
   url: string;
+
+  /**
+   * Optional diagnostics payload collected by the native layer.
+   */
+  diagnostics?: RequestDiagnostics | null;
 }
 
 /**

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -26,9 +26,9 @@ import type {
   LegacySessionWebSocketOptions,
   LegacyWebSocketOptions,
   NativeResponse,
+  NativeWebSocketConnection,
   RequestDiagnostics,
   RequestEvent,
-  NativeWebSocketConnection,
   RequestOptions,
   SessionHandle,
   SessionWebSocketOptions,
@@ -1394,8 +1394,7 @@ function resolveTransportContext(config: WreqRequestInit, sessionDefaults?: Sess
       }
     }
 
-    const captureDiagnostics =
-      config.captureDiagnostics ?? sessionDefaults.captureDiagnostics;
+    const captureDiagnostics = config.captureDiagnostics ?? sessionDefaults.captureDiagnostics;
     return {
       transportId: sessionDefaults.transportId,
       ...(captureDiagnostics !== undefined && { captureDiagnostics }),

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -26,6 +26,8 @@ import type {
   LegacySessionWebSocketOptions,
   LegacyWebSocketOptions,
   NativeResponse,
+  RequestDiagnostics,
+  RequestEvent,
   NativeWebSocketConnection,
   RequestOptions,
   SessionHandle,
@@ -96,6 +98,7 @@ interface NativeTransportOptions {
   poolMaxSize?: number;
   connectTimeout?: number;
   readTimeout?: number;
+  captureDiagnostics?: boolean;
 }
 
 interface NativeRequestOptions {
@@ -116,6 +119,8 @@ interface NativeRequestOptions {
   trustStore?: TrustStoreMode;
   transportId?: string;
   compress?: boolean;
+  captureDiagnostics?: boolean;
+  onRequestEvent?: (event: RequestEvent) => void;
 }
 
 let nativeBinding: {
@@ -320,6 +325,7 @@ type SessionDefaults = {
   insecure?: boolean;
   trustStore?: TrustStoreMode;
   defaultHeaders?: HeaderTuple[];
+  captureDiagnostics?: boolean;
   transportId?: string;
   ownsTransport?: boolean;
 };
@@ -337,6 +343,7 @@ type TransportResolution = {
   proxy?: string;
   insecure?: boolean;
   trustStore?: TrustStoreMode;
+  captureDiagnostics?: boolean;
 };
 
 type SerializedCustomEmulation = {
@@ -420,6 +427,10 @@ function normalizeSessionOptions(options?: CreateSessionOptions): { sessionId: s
 
   if (options?.defaultHeaders !== undefined) {
     defaults.defaultHeaders = headersToTuples(options.defaultHeaders);
+  }
+
+  if (options?.captureDiagnostics !== undefined) {
+    defaults.captureDiagnostics = options.captureDiagnostics;
   }
 
   return { sessionId, defaults };
@@ -685,6 +696,7 @@ function cloneNativeResponse(payload: NativeResponse): NativeResponse {
     contentLength: payload.contentLength,
     cookies: payload.cookies.map(([name, value]): HeaderTuple => [name, value]),
     url: payload.url,
+    diagnostics: payload.diagnostics ? { ...payload.diagnostics } : null,
   };
 }
 
@@ -783,6 +795,7 @@ export class Response {
   readonly ok: boolean;
   readonly contentLength: number | null;
   readonly url: string;
+  readonly diagnostics: RequestDiagnostics | null;
   readonly type: ResponseType = "basic";
   bodyUsed = false;
 
@@ -808,6 +821,7 @@ export class Response {
     this.headersInit = this.payload.headers;
     this.headersInstance = null;
     this.url = this.payload.url;
+    this.diagnostics = this.payload.diagnostics ?? null;
     this.cookiesInit = this.payload.cookies;
     this.cookiesRecord = null;
     this.contentLength = this.payload.contentLength ?? null;
@@ -1330,7 +1344,12 @@ function resolveTransportContext(config: WreqRequestInit, sessionDefaults?: Sess
       );
     }
 
-    return { transportId: config.transport.id };
+    return {
+      transportId: config.transport.id,
+      ...(config.captureDiagnostics !== undefined && {
+        captureDiagnostics: config.captureDiagnostics,
+      }),
+    };
   }
 
   if (sessionDefaults?.transportId) {
@@ -1375,7 +1394,12 @@ function resolveTransportContext(config: WreqRequestInit, sessionDefaults?: Sess
       }
     }
 
-    return { transportId: sessionDefaults.transportId };
+    const captureDiagnostics =
+      config.captureDiagnostics ?? sessionDefaults.captureDiagnostics;
+    return {
+      transportId: sessionDefaults.transportId,
+      ...(captureDiagnostics !== undefined && { captureDiagnostics }),
+    };
   }
 
   const resolved: TransportResolution = {
@@ -1388,6 +1412,9 @@ function resolveTransportContext(config: WreqRequestInit, sessionDefaults?: Sess
     resolved.insecure = config.insecure;
   }
   resolved.trustStore = config.trustStore ?? DEFAULT_TRUST_STORE;
+  if (config.captureDiagnostics !== undefined) {
+    resolved.captureDiagnostics = config.captureDiagnostics;
+  }
   return resolved;
 }
 
@@ -2519,6 +2546,13 @@ export async function fetch(input: string | URL | Request, init?: WreqRequestIni
     requestOptions.body = body;
   }
 
+  if (transport.captureDiagnostics !== undefined) {
+    requestOptions.captureDiagnostics = transport.captureDiagnostics;
+  }
+  if (config.onRequestEvent !== undefined) {
+    requestOptions.onRequestEvent = config.onRequestEvent;
+  }
+
   if (transport.transportId) {
     requestOptions.transportId = transport.transportId;
   } else {
@@ -2584,6 +2618,9 @@ export async function createTransport(options?: CreateTransportOptions): Promise
       ...(options?.poolMaxSize !== undefined && { poolMaxSize: options.poolMaxSize }),
       ...(options?.connectTimeout !== undefined && { connectTimeout: options.connectTimeout }),
       ...(options?.readTimeout !== undefined && { readTimeout: options.readTimeout }),
+      ...(options?.captureDiagnostics !== undefined && {
+        captureDiagnostics: options.captureDiagnostics,
+      }),
     };
     applyNativeEmulationMode(transportOptions, mode);
 
@@ -2606,6 +2643,9 @@ export async function createSession(options?: CreateSessionOptions): Promise<Ses
       ...(defaults.proxy !== undefined && { proxy: defaults.proxy }),
       ...(defaults.insecure !== undefined && { insecure: defaults.insecure }),
       trustStore: defaults.trustStore ?? DEFAULT_TRUST_STORE,
+      ...(defaults.captureDiagnostics !== undefined && {
+        captureDiagnostics: defaults.captureDiagnostics,
+      }),
     };
     applyNativeEmulationMode(transportOptions, defaults.transportMode);
     transportId = nativeBinding.createTransport(transportOptions);
@@ -2725,6 +2765,14 @@ export async function request(options: RequestOptions): Promise<Response> {
     init.cookieMode = legacy.cookieMode;
   } else if (legacy.ephemeral === true) {
     init.cookieMode = "ephemeral";
+  }
+
+  if (legacy.onRequestEvent !== undefined) {
+    init.onRequestEvent = legacy.onRequestEvent;
+  }
+
+  if (legacy.captureDiagnostics !== undefined) {
+    init.captureDiagnostics = legacy.captureDiagnostics;
   }
 
   return fetch(url, init);
@@ -3776,6 +3824,9 @@ export type {
   Http2PseudoHeaderId,
   Http2SettingId,
   Http2StreamDependency,
+  RequestDiagnostics,
+  RequestEvent,
+  RequestEventType,
   RequestInit,
   RequestOptions,
   SessionHandle,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
-
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- add optional request progress event callbacks spanning request start, send, headers, body progress, completion, and error
- expose the new progress event types through the JS/TS bridge without changing the existing fetch/session API shape
- keep the change focused on observability so downstream tools can render more accurate transport-phase progress

## Why
Downstream consumers such as agent-smart-fetch need more granular network lifecycle events than a single monolithic request call in order to surface better progress states like connecting, waiting, and loading.

## Notes
- no package rename or fork-specific metadata is included in this PR
- the fork-only metadata/docs changes live separately on the fork
