### PR TITLE
fix: use system CA store for TLS verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,10 @@ jobs:
           WREQ_TARGET: ${{ matrix.settings.target }}
         run: node scripts/smoke-native.cjs
 
+      - name: Smoke test TLS verification
+        if: matrix.settings.target == 'x86_64-unknown-linux-gnu'
+        run: npm run build:ts && npm run smoke:tls
+
       - name: Smoke test native addon (musl)
         if: matrix.settings.target == 'x86_64-unknown-linux-musl'
         run: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -120,6 +120,10 @@ jobs:
       - name: Run tests
         run: npm exec -- tsx src/test/run-with-local-server.ts
 
+      - name: Run live TLS smoke test
+        if: matrix.os == 'ubuntu-24.04' && matrix.node-version == 24 && matrix.arch == 'x64'
+        run: npm run build:ts && npm run smoke:tls
+
   lint:
     name: Lint
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,10 @@ jobs:
           WREQ_PLATFORM_ARCH: ${{ matrix.platform-arch }}
         run: node scripts/smoke-native.cjs
 
+      - name: Smoke test TLS verification
+        if: matrix.platform-arch == 'linux-x64-gnu'
+        run: npm run build:ts && npm run smoke:tls
+
       - name: Upload native addon artifact
         uses: actions/upload-artifact@v7
         with:
@@ -196,6 +200,10 @@ jobs:
       - name: Run coverage tests
         if: matrix.os == 'ubuntu-24.04' && matrix.node-version == 24 && matrix.arch == 'x64'
         run: npm exec -- c8 --reporter=text-summary --reporter=lcov -- tsx src/test/run-with-local-server.ts
+
+      - name: Run live TLS smoke test
+        if: matrix.os == 'ubuntu-24.04' && matrix.node-version == 24 && matrix.arch == 'x64'
+        run: npm run build:ts && npm run smoke:tls
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-24.04' && matrix.node-version == 24 && matrix.arch == 'x64'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:rust": "napi build --platform --release --manifest-path rust/Cargo.toml",
     "build:ts": "tsup",
     "artifacts": "napi artifacts",
+    "smoke:tls": "node scripts/smoke-tls.cjs",
     "test": "npm run test:run",
     "test:run": "tsx src/test/run-with-local-server.ts",
     "test:build": "npm run build && npm run test:run",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1166,12 +1166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,15 +1786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,7 +2058,6 @@ dependencies = [
  "tower-http",
  "url",
  "want",
- "webpki-root-certs",
  "windows-registry",
  "zstd",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # HTTP client with browser impersonation
-wreq = { version = "6.0.0-rc.28", default-features = false, features = ["cookies", "gzip", "brotli", "deflate", "zstd", "charset", "system-proxy", "socks", "ws", "stream", "webpki-roots"] }
+wreq = { version = "6.0.0-rc.28", default-features = false, features = ["cookies", "gzip", "brotli", "deflate", "zstd", "charset", "system-proxy", "socks", "ws", "stream"] }
 wreq-util = { version = "3.0.0-rc.10", features = ["emulation-serde", "emulation-rand"] }
 
 # WebSocket support

--- a/scripts/smoke-tls.cjs
+++ b/scripts/smoke-tls.cjs
@@ -1,0 +1,24 @@
+const { fetch } = require("../dist/wreq-js.cjs");
+
+const urls = ["https://example.com", "https://iana.org"];
+
+async function main() {
+  for (const url of urls) {
+    try {
+      const response = await fetch(url, {
+        browser: "chrome_145",
+        timeout: 15_000,
+      });
+      if (!response.ok) {
+        throw new Error(`Unexpected status ${response.status} ${response.statusText}`);
+      }
+      console.log(`tls-smoke-ok ${url} -> ${response.status}`);
+    } catch (error) {
+      const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+      console.error(`tls-smoke-fail ${url}\n${message}`);
+      process.exit(1);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

This fixes `CERTIFICATE_VERIFY_FAILED` for sites that are trusted by the host CA store but are not trusted by the embedded Mozilla/webpki bundle.

The concrete case I hit was:

- `https://example.com` failed from `wreq-js`
- `curl https://example.com` succeeded from the same container / host

## Root cause

In `rust/Cargo.toml`, this wrapper currently depends on `wreq` with:

```toml
wreq = { version = "6.0.0-rc.28", default-features = false, features = [ ..., "webpki-roots" ] }
```

That forces TLS verification to use the static `webpki-root-certs` bundle instead of the system certificate store.

For `example.com`, the served chain currently validates against the system CA bundle but fails against the embedded Mozilla-style bundle. So `curl` succeeds while `wreq-js` fails with:

```text
[CERTIFICATE_VERIFY_FAILED]
```

`wreq` itself documents this behavior:
- `webpki-roots` uses a static Mozilla bundle
- omitting it falls back to the system default certificate paths

## Reproduction

From the same environment:

```bash
curl -v https://example.com
# succeeds
```

```js
import { fetch } from "wreq-js";
await fetch("https://example.com", { browser: "chrome_145", timeout: 15000 });
// CERTIFICATE_VERIFY_FAILED before this patch
```

I also reproduced this in a plugin environment where the target site was a normal public HTTPS endpoint and only `wreq-js` failed.

## What this PR changes

1. Remove the explicit `webpki-roots` feature from the wrapper's `wreq` dependency.
   - this makes `wreq` use the system CA store
   - behavior now matches `curl` / normal host trust expectations

2. Add a small live TLS smoke check for CI/release flows.
   - `https://example.com`
   - `https://iana.org`

The goal of the smoke check is to catch regressions where:
- the native addon loads fine
- ordinary tests still pass
- but TLS trust behavior diverges from the host environment

## Validation

After this change:

- `fetch("https://example.com")` succeeds
- `fetch("https://iana.org")` succeeds
- `curl` and `wreq-js` agree again on trust outcome for the repro case

## Notes

This is intentionally **not** using `insecure: true`.

The problem was not an invalid target certificate; it was the wrapper forcing a different trust store than the host.
