### PR TITLE
feat: explicit resource management

### DIFF
--- a/src/test/unit/disposal.spec.ts
+++ b/src/test/unit/disposal.spec.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { Session, Transport, WebSocket } from "../../wreq-js.js";
+
+describe("explicit resource management", () => {
+  test("await using closes a Transport", async () => {
+    const transport = new Transport("test-transport");
+    let closeCalls = 0;
+    transport.close = async () => {
+      closeCalls += 1;
+    };
+
+    {
+      await using resource = transport;
+      assert.strictEqual(resource, transport);
+      assert.strictEqual(closeCalls, 0);
+    }
+
+    assert.strictEqual(closeCalls, 1);
+  });
+
+  test("await using closes a Session", async () => {
+    const session = Object.create(Session.prototype) as Session;
+    let closeCalls = 0;
+    session.close = async () => {
+      closeCalls += 1;
+    };
+
+    {
+      await using resource = session;
+      assert.strictEqual(resource, session);
+      assert.strictEqual(closeCalls, 0);
+    }
+
+    assert.strictEqual(closeCalls, 1);
+  });
+
+  test("using closes a WebSocket", () => {
+    const socket = Object.create(WebSocket.prototype) as WebSocket;
+    let closeCalls = 0;
+    socket.close = () => {
+      closeCalls += 1;
+    };
+
+    {
+      using resource = socket;
+      assert.strictEqual(resource, socket);
+      assert.strictEqual(closeCalls, 0);
+    }
+
+    assert.strictEqual(closeCalls, 1);
+  });
+});

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -1127,6 +1127,10 @@ export class Transport {
       throw new RequestError(String(error));
     }
   }
+
+  async [Symbol.asyncDispose]() {
+    await this.close();
+  }
 }
 
 export class Session implements SessionHandle {
@@ -1288,6 +1292,10 @@ export class Session implements SessionHandle {
         throw new RequestError(String(error));
       }
     }
+  }
+
+  async [Symbol.asyncDispose]() {
+    await this.close();
   }
 }
 
@@ -3729,6 +3737,10 @@ export class WebSocket {
     this._closeOptions = normalizeWebSocketCloseOptions(code, reason);
     this.readyState = WebSocket.CLOSING;
     this.startNativeClose();
+  }
+
+  [Symbol.dispose]() {
+    this.close();
   }
 }
 


### PR DESCRIPTION
Add [explicit resource management](https://v8.dev/features/explicit-resource-management), so that users can use `using` statement instead of boilerplate and forgettable `try-finally`:

```typescript
import { createSession } from 'wreq-js';

// original try-finally
const session = await createSession({ browser: 'chrome_142', os: 'windows' });
try {
  await session.fetch('https://example.com/a');
} finally {
  await session.close();
}

// with EMR using statement
await using session = await createSession({ browser: 'chrome_142', os: 'windows' });
await session.fetch('https://example.com/a');
```

I'm not sure if tests are required as `using` is just a syntax sugar around the `.close()` method.