### PR TITLE
fix: add Headers.getSetCookie() and fix Set-Cookie iterator folding

### DIFF
--- a/src/test/run-with-local-server.ts
+++ b/src/test/run-with-local-server.ts
@@ -16,12 +16,22 @@ const httpTestFiles = existsSync(httpTestDir)
       .sort()
   : [];
 
+const unitTestDir = resolve(testDir, "unit");
+const unitTestFiles = existsSync(unitTestDir)
+  ? readdirSync(unitTestDir)
+      .filter((filename) => filename.endsWith(".spec.ts") || filename.endsWith(".spec.js"))
+      .map((filename) => resolve(unitTestDir, filename))
+      .sort()
+  : [];
+
 async function main() {
   const extraArgs = process.argv.slice(2);
   const websocketTestFile = ["websocket.spec.ts", "websocket.spec.js"]
     .map((filename) => resolve(testDir, filename))
     .find((filename) => existsSync(filename));
-  const defaultTestFiles = websocketTestFile ? [...httpTestFiles, websocketTestFile] : httpTestFiles;
+  const defaultTestFiles = websocketTestFile
+    ? [...unitTestFiles, ...httpTestFiles, websocketTestFile]
+    : [...unitTestFiles, ...httpTestFiles];
 
   const normalizeArg = (arg: string): string => {
     const abs = resolve(process.cwd(), arg);

--- a/src/test/unit/headers.spec.ts
+++ b/src/test/unit/headers.spec.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { Headers } from "../../wreq-js.js";
+
+describe("Headers — Set-Cookie spec compliance", () => {
+  test("getSetCookie returns empty array when absent", () => {
+    const h = new Headers();
+    assert.deepStrictEqual(h.getSetCookie(), []);
+  });
+
+  test("getSetCookie returns single value", () => {
+    const h = new Headers([["set-cookie", "a=1; Path=/"]]);
+    assert.deepStrictEqual(h.getSetCookie(), ["a=1; Path=/"]);
+  });
+
+  test("getSetCookie returns all values independently", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1; Path=/");
+    h.append("set-cookie", "b=2; HttpOnly");
+    assert.deepStrictEqual(h.getSetCookie(), ["a=1; Path=/", "b=2; HttpOnly"]);
+  });
+
+  test("getSetCookie value contains comma (Expires field)", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1; Expires=Fri, 01 Jan 2027 00:00:00 GMT");
+    h.append("set-cookie", "b=2");
+    const cookies = h.getSetCookie();
+    assert.strictEqual(cookies.length, 2);
+    assert.ok(cookies[0]?.includes("Expires=Fri, 01 Jan 2027"), "comma in Expires must not split the value");
+  });
+
+  test("get('set-cookie') returns comma-joined string for backward compat", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1");
+    h.append("set-cookie", "b=2");
+    assert.strictEqual(h.get("set-cookie"), "a=1, b=2");
+  });
+
+  test("iterator yields one tuple per set-cookie value", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1");
+    h.append("set-cookie", "b=2");
+    const tuples = [...h];
+    const sc = tuples.filter(([n]) => n.toLowerCase() === "set-cookie");
+    assert.strictEqual(sc.length, 2);
+    assert.strictEqual(sc[0]?.[1], "a=1");
+    assert.strictEqual(sc[1]?.[1], "b=2");
+  });
+
+  test("toTuples emits separate tuples for each set-cookie value", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1");
+    h.append("set-cookie", "b=2");
+    const tuples = h.toTuples();
+    const sc = tuples.filter(([n]) => n.toLowerCase() === "set-cookie");
+    assert.strictEqual(sc.length, 2);
+  });
+
+  test("toObject uses comma-join for set-cookie (lossy, consistent with get)", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1");
+    h.append("set-cookie", "b=2");
+    const obj = h.toObject();
+    const val = obj["set-cookie"] ?? obj["Set-Cookie"];
+    assert.strictEqual(val, "a=1, b=2");
+  });
+
+  test("round-trip via new Headers(existingHeaders) preserves set-cookie values", () => {
+    const src = new Headers();
+    src.append("set-cookie", "a=1");
+    src.append("set-cookie", "b=2");
+    const clone = new Headers(src);
+    assert.deepStrictEqual(clone.getSetCookie(), ["a=1", "b=2"]);
+  });
+
+  test("non-set-cookie multi-value still comma-joins (existing behaviour)", () => {
+    const h = new Headers({ "X-Test": "alpha" });
+    h.append("x-test", "beta");
+    assert.strictEqual(h.get("X-Test"), "alpha, beta");
+  });
+
+  test("keys() emits set-cookie once per value", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1");
+    h.append("set-cookie", "b=2");
+    const keys = [...h.keys()];
+    assert.strictEqual(keys.filter((k) => k.toLowerCase() === "set-cookie").length, 2);
+  });
+
+  test("forEach calls callback once per set-cookie value", () => {
+    const h = new Headers();
+    h.append("set-cookie", "a=1");
+    h.append("set-cookie", "b=2");
+    const seen: string[] = [];
+    h.forEach((v, n) => {
+      if (n.toLowerCase() === "set-cookie") seen.push(v);
+    });
+    assert.deepStrictEqual(seen, ["a=1", "b=2"]);
+  });
+});

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -562,6 +562,12 @@ export class Headers implements Iterable<[string, string]> {
     return entry ? entry.values.join(", ") : null;
   }
 
+  getSetCookie(): string[] {
+    const entry = this.store.get("set-cookie");
+    if (!entry) return [];
+    return [...entry.values];
+  }
+
   has(name: string): boolean {
     const normalized = this.normalizeName(name);
     return this.store.has(normalized.key);
@@ -597,7 +603,13 @@ export class Headers implements Iterable<[string, string]> {
   [Symbol.iterator](): IterableIterator<[string, string]> {
     const generator = function* (store: Map<string, HeaderStoreEntry>) {
       for (const entry of store.values()) {
-        yield [entry.name, entry.values.join(", ")] as [string, string];
+        if (entry.name.toLowerCase() === "set-cookie") {
+          for (const v of entry.values) {
+            yield [entry.name, v] as [string, string];
+          }
+        } else {
+          yield [entry.name, entry.values.join(", ")] as [string, string];
+        }
       }
     };
 
@@ -607,8 +619,8 @@ export class Headers implements Iterable<[string, string]> {
   toObject(): Record<string, string> {
     const result: Record<string, string> = {};
 
-    for (const [name, value] of this) {
-      result[name] = value;
+    for (const entry of this.store.values()) {
+      result[entry.name] = entry.values.join(", ");
     }
 
     return result;


### PR DESCRIPTION
## Fixes #148

### Problem

`Headers.get("set-cookie")` comma-folds multiple `Set-Cookie` values into a single string (`"a=1, b=2"`), violating [RFC 6265 §3](https://datatracker.ietf.org/doc/html/rfc6265#section-3) and the [Fetch spec](https://fetch.spec.whatwg.org/#dom-headers-getsetcookie) which explicitly forbids combining `Set-Cookie` fields. The `getSetCookie()` method required by the spec does not exist.

This causes silent cookie loss when multiple `Set-Cookie` headers are present (e.g. `__Secure-next-auth.session-token` + `__cf_bm`) — a common pattern in NextAuth.js flows.

### Changes

**`src/wreq-js.ts` — Headers class:**

1. **Added `getSetCookie(): string[]`** — returns individual `Set-Cookie` values as an array, matching the [native Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie). Returns `[]` when absent.

2. **Fixed `[Symbol.iterator]`** — yields one `[name, value]` tuple **per** `Set-Cookie` value instead of comma-folding. All other headers retain the existing `values.join(", ")` behavior.

3. **Fixed `toObject()`** — iterates `store.values()` directly (bypasses the multi-tuple iterator expansion) to avoid duplicate keys in the returned `Record<string, string>`. Comma-joins all headers including `Set-Cookie`, consistent with `get()`.

**`src/test/unit/headers.spec.ts` — new test file:**

12 test cases covering:
- `getSetCookie()` — empty, single, multiple, comma-in-Expires field
- `get("set-cookie")` — backward-compatible comma-joined string
- Iterator — one tuple per Set-Cookie value
- `toTuples()` — separate tuples per Set-Cookie value
- `toObject()` — comma-join (lossy but consistent with `Record<string, string>`)
- Round-trip via `new Headers(existingHeaders)` — preserves individual Set-Cookie values
- `keys()` / `forEach()` — one entry per Set-Cookie value
- Non-Set-Cookie multi-value — still comma-joins (existing behavior unchanged)

**`src/test/run-with-local-server.ts`** — auto-discovers `unit/*.spec.ts` alongside existing `http/*.spec.ts`.

### Backward Compatibility

| Method | Before | After |
|---|---|---|
| `get("set-cookie")` | `"a=1, b=2"` | `"a=1, b=2"` (unchanged) |
| `getSetCookie()` | N/A (missing) | `["a=1", "b=2"]` |
| `toTuples()` for Set-Cookie | `["set-cookie", "a=1, b=2"]` | `["set-cookie", "a=1"], ["set-cookie", "b=2"]` |
| `toObject()` for Set-Cookie | `"a=1, b=2"` | `"a=1, b=2"` (unchanged) |
| `get("X-Test")` multi-value | `"alpha, beta"` | `"alpha, beta"` (unchanged) |

`get()` remains comma-joined for all headers including `set-cookie`, matching the WHATWG spec's acknowledged legacy behavior. `getSetCookie()` is the authoritative accessor.

### Verification

```
✔ Headers — Set-Cookie spec compliance (12 tests, 0 failures)
✔ supports the Headers helper API (existing test, backward compat confirmed)
✔ TypeScript typecheck: clean
✔ Biome lint: clean
```