### PR TITLE
feat: add headerOverrides for surgical emulation header replacement

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -124,6 +124,7 @@ pub struct RequestOptions {
     pub browser_os: Option<BrowserEmulationOS>,
     pub emulation_json: Option<Arc<str>>,
     pub headers: Vec<(String, String)>,
+    pub header_overrides: Vec<(String, String)>,
     pub method: String,
     pub body: Option<Vec<u8>>,
     pub proxy: Option<Arc<str>>,
@@ -573,6 +574,7 @@ async fn make_request_inner(
     let RequestOptions {
         url,
         headers,
+        header_overrides,
         method,
         body,
         timeout,
@@ -618,9 +620,15 @@ async fn make_request_inner(
     // Apply custom headers and preserve their original casing.
     // Merge with emulation-level origHeaders so that custom emulation header
     // casing/order is preserved even when the request adds explicit headers.
-    if !headers.is_empty() {
+    let has_headers = !headers.is_empty();
+    let has_overrides = !header_overrides.is_empty();
+    if has_headers || has_overrides {
         let mut orig = resolved.emulation_orig_headers.clone();
         for (key, value) in headers.iter() {
+            request = request.header(key, value);
+            orig.insert(key.clone());
+        }
+        for (key, value) in header_overrides.iter() {
             request = request.header(key, value);
             orig.insert(key.clone());
         }
@@ -975,6 +983,7 @@ mod tests {
             browser_os: Some(BrowserEmulationOS::MacOS),
             emulation_json: None,
             headers: Vec::new(),
+            header_overrides: Vec::new(),
             method: "GET".to_string(),
             body: None,
             proxy: None,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -203,6 +203,13 @@ fn js_object_to_request_options(
         Vec::new()
     };
 
+    // Get headerOverrides (optional) — surgically replace emulation headers
+    let header_overrides = if let Ok(Some(val)) = obj.get_opt(cx, "headerOverrides") {
+        parse_headers_from_value(cx, val)?
+    } else {
+        Vec::new()
+    };
+
     // Get body (optional)
     let body = if let Some(body_value) = obj.get_opt::<JsValue, _, _>(cx, "body")? {
         if body_value.is_a::<JsUndefined, _>(cx) || body_value.is_a::<JsNull, _>(cx) {
@@ -326,6 +333,7 @@ fn js_object_to_request_options(
         browser_os,
         emulation_json,
         headers,
+        header_overrides,
         method,
         body,
         proxy,

--- a/src/test/http/headers.spec.ts
+++ b/src/test/http/headers.spec.ts
@@ -113,4 +113,35 @@ describe("HTTP headers", () => {
     assert.strictEqual(headers.get("x-another"), "value", "set should overwrite values");
     assert.ok(collected.length >= 2, "entries should iterate all headers");
   });
+
+  test("headerOverrides replaces specific emulation headers", async () => {
+    const customAccept = "text/html";
+    const response = await wreqFetch(httpUrl("/headers"), {
+      browser: "chrome_142",
+      headerOverrides: [["Accept", customAccept]],
+      timeout: 10000,
+    });
+
+    assert.strictEqual(response.status, 200, "Should return status 200");
+    const body = await response.json<{ headers: Record<string, string>; rawHeaders: string[] }>();
+
+    assert.strictEqual(body.headers.Accept, customAccept, "Accept should be overridden to custom value");
+    assert.ok(body.headers["User-Agent"], "User-Agent emulation header should be preserved");
+  });
+
+  test("headerOverrides with headers coexist", async () => {
+    const response = await wreqFetch(httpUrl("/headers"), {
+      browser: "chrome_142",
+      headers: { "X-Custom": "foo" },
+      headerOverrides: [["Accept", "text/html"]],
+      timeout: 10000,
+    });
+
+    assert.strictEqual(response.status, 200, "Should return status 200");
+    const body = await response.json<{ headers: Record<string, string> }>();
+
+    assert.strictEqual(body.headers.Accept, "text/html", "Accept should be overridden");
+    assert.strictEqual(body.headers["X-Custom"], "foo", "Custom header should be present");
+    assert.ok(body.headers["User-Agent"], "User-Agent emulation header should be preserved");
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,6 +389,15 @@ export interface RequestInit {
   disableDefaultHeaders?: boolean;
 
   /**
+   * Surgically replace specific emulation-injected headers while preserving
+   * the rest of the browser profile defaults. Each entry replaces the
+   * matching header by name. Use instead of `disableDefaultHeaders` when
+   * you want to override specific headers without losing the full emulation
+   * profile.
+   */
+  headerOverrides?: HeadersInit;
+
+  /**
    * Disable HTTPS certificate verification. When enabled, self-signed and invalid
    * certificates will be accepted.
    * Ignored when `transport` is provided.
@@ -694,6 +703,13 @@ export interface RequestOptions {
    * @default false
    */
   disableDefaultHeaders?: boolean;
+
+  /**
+   * Surgically replace specific emulation-injected headers while preserving
+   * the rest of the browser profile defaults. Each entry replaces the
+   * matching header by name.
+   */
+  headerOverrides?: HeadersInit;
 
   /**
    * Disable HTTPS certificate verification. When enabled, self-signed and invalid

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -116,6 +116,7 @@ interface NativeRequestOptions {
   sessionId: string;
   ephemeral: boolean;
   disableDefaultHeaders?: boolean;
+  headerOverrides?: HeaderTuple[];
   insecure?: boolean;
   trustStore?: TrustStoreMode;
   transportId?: string;
@@ -2600,6 +2601,12 @@ export async function fetch(input: string | URL | Request, init?: WreqRequestIni
   if (config.disableDefaultHeaders !== undefined) {
     requestOptions.disableDefaultHeaders = config.disableDefaultHeaders;
   }
+  if (config.headerOverrides !== undefined) {
+    const overrideTuples = headersToTuples(config.headerOverrides);
+    if (overrideTuples.length > 0) {
+      requestOptions.headerOverrides = overrideTuples;
+    }
+  }
   if (config.compress !== undefined) {
     requestOptions.compress = config.compress;
   }
@@ -2770,6 +2777,11 @@ export async function request(options: RequestOptions): Promise<Response> {
 
   if (rest.disableDefaultHeaders !== undefined) {
     init.disableDefaultHeaders = rest.disableDefaultHeaders;
+  }
+
+  const legacyOverrides = (rest as Partial<WreqRequestInit>).headerOverrides;
+  if (legacyOverrides !== undefined) {
+    init.headerOverrides = legacyOverrides;
   }
 
   if (rest.redirect !== undefined) {


### PR DESCRIPTION
## Addresses #145 (second part)

### Problem

Users who want to replace specific emulation-injected headers (e.g. override `Accept` while keeping `User-Agent`, `Accept-Language`, etc.) currently have no option besides `disableDefaultHeaders: true` — which strips **all** emulation headers. This forces manual reconstruction of the entire header set, defeating the purpose of browser fingerprinting.

### Solution

Add `headerOverrides?: HeadersInit` to `RequestInit` and `RequestOptions`. Headers listed in `headerOverrides` replace matching emulation-injected headers by name, while all other emulation headers are preserved.

```js
const response = await fetch("https://example.com", {
  browser: "chrome_142",
  headerOverrides: [
    ["Accept", "text/html"],
    ["Accept-Language", "en-US"],
  ],
});
// User-Agent, Accept-Encoding, Sec-CH-UA, etc. still come from chrome_142
// Only Accept and Accept-Language are replaced
```

### How it works

**JS layer** — `headerOverrides` is converted to `HeaderTuple[]` and threaded through `NativeRequestOptions` to the Rust native binding.

**Rust layer** — `RequestOptions.header_overrides: Vec<(String, String)>` is applied in `make_request_inner()` after `headers`, using the same `request.header(key, value)` call which replaces by name. Both `headers` and `header_overrides` share a single `orig_headers` pass to preserve casing.

### Changes

| File | Change |
|---|---|
| `rust/src/client.rs` | Add `header_overrides` field to `RequestOptions`, merge with `headers` in single `orig` pass |
| `rust/src/lib.rs` | Parse `headerOverrides` from JS object into `RequestOptions` |
| `src/types.ts` | Add `headerOverrides?: HeadersInit` to `RequestInit` and `RequestOptions` |
| `src/wreq-js.ts` | Add to `NativeRequestOptions`, thread through `fetch()` and legacy `request()` |
| `src/test/http/headers.spec.ts` | 2 new integration tests |

### Test Results

```
163/163 pass (full suite with local HTTP server)
```

New tests:
- `headerOverrides replaces specific emulation headers` — verifies Accept is overridden while User-Agent is preserved
- `headerOverrides with headers coexist` — verifies custom headers + overrides + emulation all work together

### vs `disableDefaultHeaders`

| | `disableDefaultHeaders: true` | `headerOverrides` |
|---|---|---|
| Emulation headers | All stripped | Only specified ones replaced |
| Custom headers | Must reconstruct everything | Add alongside as usual |
| Fingerprint integrity | Broken (no UA, no encoding) | Preserved (only named overrides) |