### PR TITLE
Add a resolve option to override DNS for specific hosts

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -4,6 +4,7 @@ use dashmap::DashMap;
 use futures_util::{Stream, StreamExt};
 use moka::sync::Cache;
 use std::borrow::Cow;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -201,6 +202,7 @@ struct TransportConfig {
     connect_timeout: Option<Duration>,
     read_timeout: Option<Duration>,
     capture_diagnostics: bool,
+    resolve: Vec<(String, Vec<SocketAddr>)>,
 }
 
 impl TransportConfig {
@@ -219,6 +221,7 @@ impl TransportConfig {
             connect_timeout: options.connect_timeout.map(Duration::from_millis),
             read_timeout: options.read_timeout.map(Duration::from_millis),
             capture_diagnostics: options.capture_diagnostics,
+            resolve: Vec::new(),
         }
     }
 
@@ -236,6 +239,7 @@ impl TransportConfig {
         connect_timeout: Option<u64>,
         read_timeout: Option<u64>,
         capture_diagnostics: bool,
+        resolve: Vec<(String, Vec<SocketAddr>)>,
     ) -> Self {
         Self {
             browser,
@@ -250,6 +254,7 @@ impl TransportConfig {
             connect_timeout: connect_timeout.map(Duration::from_millis),
             read_timeout: read_timeout.map(Duration::from_millis),
             capture_diagnostics,
+            resolve,
         }
     }
 }
@@ -584,12 +589,7 @@ async fn make_request_inner(
         ..
     } = options;
     let start = Instant::now();
-    emit_request_event(
-        &event_sink,
-        RequestEvent::RequestStart {
-            timestamp_ms: 0,
-        },
-    );
+    emit_request_event(&event_sink, RequestEvent::RequestStart { timestamp_ms: 0 });
 
     // Methods are already normalized to uppercase in JS; default to GET when empty.
     let method = if method.is_empty() {
@@ -809,6 +809,10 @@ fn build_client(config: &TransportConfig) -> Result<ResolvedClient> {
         client_builder = client_builder.cert_store(build_cert_store(config.trust_store)?);
     }
 
+    for (domain, addrs) in &config.resolve {
+        client_builder = client_builder.resolve_to_addrs(domain.clone(), addrs.iter().copied());
+    }
+
     if let Some(pool_idle_timeout) = config.pool_idle_timeout {
         client_builder = client_builder.pool_idle_timeout(pool_idle_timeout);
     }
@@ -923,6 +927,7 @@ pub fn create_managed_transport(
     connect_timeout: Option<u64>,
     read_timeout: Option<u64>,
     capture_diagnostics: bool,
+    resolve: Vec<(String, Vec<SocketAddr>)>,
 ) -> Result<String> {
     let config = TransportConfig::new(
         browser,
@@ -937,6 +942,7 @@ pub fn create_managed_transport(
         connect_timeout,
         read_timeout,
         capture_diagnostics,
+        resolve,
     );
     TRANSPORT_MANAGER.create_transport(config)
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,11 +5,11 @@ mod websocket;
 
 use anyhow::anyhow;
 use client::{
-    HTTP_RUNTIME, RedirectMode, RequestEvent, RequestOptions, Response,
+    HTTP_RUNTIME, RedirectMode, RequestEvent, RequestOptions, Response, TrustStoreMode,
     clear_managed_session, create_managed_session, create_managed_transport, drop_body_stream,
     drop_managed_session, drop_managed_transport, generate_session_id, get_all_session_cookies,
     get_session_cookies, make_request, read_body_all as native_read_body_all,
-    read_body_chunk as native_read_body_chunk, set_session_cookie, TrustStoreMode,
+    read_body_chunk as native_read_body_chunk, set_session_cookie,
 };
 use dashmap::DashMap;
 use futures_util::StreamExt;
@@ -19,6 +19,7 @@ use neon::types::{
     buffer::TypedArray,
 };
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::sync::LazyLock;
 use tokio::sync::{Semaphore, mpsc};
@@ -160,6 +161,81 @@ fn parse_headers_from_value(
     }
 
     cx.throw_type_error("headers must be an array or object")
+}
+
+fn parse_socket_addr(value: &str) -> Option<SocketAddr> {
+    if let Ok(addr) = value.parse::<SocketAddr>() {
+        return Some(addr);
+    }
+
+    // The port is ignored by wreq (the request URL's port is used), so a bare IP
+    // address is accepted and paired with a placeholder port.
+    value
+        .parse::<IpAddr>()
+        .ok()
+        .map(|ip| SocketAddr::new(ip, 0))
+}
+
+fn parse_resolve_from_object(
+    cx: &mut FunctionContext,
+    obj: Handle<JsObject>,
+) -> NeonResult<Vec<(String, Vec<SocketAddr>)>> {
+    let keys = obj.get_own_property_names(cx)?;
+    let keys_vec = keys.to_vec(cx)?;
+    let mut entries = Vec::with_capacity(keys_vec.len());
+
+    for key_val in keys_vec {
+        let Ok(key_str) = key_val.downcast::<JsString, _>(cx) else {
+            continue;
+        };
+        let host = key_str.value(cx);
+        let value: Handle<JsValue> = obj.get(cx, host.as_str())?;
+
+        let raw_values = if let Ok(array) = value.downcast::<JsArray, _>(cx) {
+            array.to_vec(cx)?
+        } else if value.is_a::<JsString, _>(cx) {
+            vec![value]
+        } else {
+            return cx.throw_type_error("resolve values must be a string or array of strings");
+        };
+
+        let mut addrs = Vec::with_capacity(raw_values.len());
+        for raw in raw_values {
+            let Ok(addr_str) = raw.downcast::<JsString, _>(cx) else {
+                return cx.throw_type_error("resolve addresses must be strings");
+            };
+            match parse_socket_addr(&addr_str.value(cx)) {
+                Some(addr) => addrs.push(addr),
+                None => {
+                    return cx
+                        .throw_type_error(format!("Invalid resolve address for host '{}'", host));
+                }
+            }
+        }
+
+        if !addrs.is_empty() {
+            entries.push((host, addrs));
+        }
+    }
+
+    Ok(entries)
+}
+
+fn parse_resolve_opt(
+    cx: &mut FunctionContext,
+    obj: Handle<JsObject>,
+    key: &str,
+) -> NeonResult<Vec<(String, Vec<SocketAddr>)>> {
+    let Some(value) = obj.get_opt::<JsValue, _, _>(cx, key)? else {
+        return Ok(Vec::new());
+    };
+
+    if value.is_a::<JsUndefined, _>(cx) || value.is_a::<JsNull, _>(cx) {
+        return Ok(Vec::new());
+    }
+
+    let resolve_obj = value.downcast_or_throw::<JsObject, _>(cx)?;
+    parse_resolve_from_object(cx, resolve_obj)
 }
 
 // Convert JS object to RequestOptions
@@ -546,7 +622,11 @@ fn request_event_to_js_object<'a, C: Context<'a>>(
                 }
             };
         }
-        RequestEvent::Done { timestamp_ms, status, url } => {
+        RequestEvent::Done {
+            timestamp_ms,
+            status,
+            url,
+        } => {
             let event_type = cx.string("done");
             let timestamp = cx.number(timestamp_ms as f64);
             let status_value = cx.number(status as f64);
@@ -736,10 +816,23 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
         connect_timeout_opt,
         read_timeout_opt,
         capture_diagnostics_opt,
+        resolve,
     ) = if let Some(value) = options_value {
         if value.is_a::<JsUndefined, _>(&mut cx) || value.is_a::<JsNull, _>(&mut cx) {
             (
-                None, None, None, None, None, None, None, None, None, None, None, None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Vec::new(),
             )
         } else {
             let obj = value.downcast_or_throw::<JsObject, _>(&mut cx)?;
@@ -791,6 +884,7 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
                 .get_opt(&mut cx, "captureDiagnostics")?
                 .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(&mut cx).ok())
                 .map(|v| v.value(&mut cx));
+            let resolve = parse_resolve_opt(&mut cx, obj, "resolve")?;
 
             (
                 browser,
@@ -805,11 +899,24 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
                 connect_timeout,
                 read_timeout,
                 capture_diagnostics,
+                resolve,
             )
         }
     } else {
         (
-            None, None, None, None, None, None, None, None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
         )
     };
 
@@ -835,6 +942,7 @@ fn create_transport(mut cx: FunctionContext) -> JsResult<JsString> {
         connect_timeout_opt,
         read_timeout_opt,
         capture_diagnostics,
+        resolve,
     ) {
         Ok(id) => Ok(cx.string(id)),
         Err(e) => {

--- a/src/test/http/resolve.spec.ts
+++ b/src/test/http/resolve.spec.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { createTransport, fetch as wreqFetch } from "../../wreq-js.js";
+
+const SELF_SIGNED_URL = process.env.HTTPS_SELF_SIGNED_URL;
+const CUSTOM_CA_URL = process.env.HTTPS_CUSTOM_CA_URL;
+
+if (!SELF_SIGNED_URL || !CUSTOM_CA_URL) {
+  throw new Error("HTTPS_SELF_SIGNED_URL and HTTPS_CUSTOM_CA_URL must be set by the test runner");
+}
+
+const CUSTOM_CA_PORT = new URL(CUSTOM_CA_URL).port;
+
+// `.invalid` is reserved by RFC 6761 and never resolves, so the only way a
+// request reaches the local server is through the resolve override.
+const PINNED_HOST = "wreq-resolve-test.invalid";
+const PORT = new URL(SELF_SIGNED_URL).port;
+const PINNED_URL = `https://${PINNED_HOST}:${PORT}/json`;
+
+describe("DNS resolve override", () => {
+  test("routes an otherwise unresolvable host to the provided address", async () => {
+    const transport = await createTransport({
+      browser: "chrome_142",
+      insecure: true,
+      resolve: { [PINNED_HOST]: `127.0.0.1:${PORT}` },
+    });
+
+    try {
+      const response = await wreqFetch(PINNED_URL, { transport, timeout: 10_000 });
+
+      assert.equal(response.status, 200);
+      const body = (await response.json()) as { message?: string };
+      assert.equal(body.message, "local test server");
+    } finally {
+      await transport.close();
+    }
+  });
+
+  test("accepts an array of addresses for a host", async () => {
+    const transport = await createTransport({
+      browser: "chrome_142",
+      insecure: true,
+      resolve: { [PINNED_HOST]: [`127.0.0.1:${PORT}`] },
+    });
+
+    try {
+      const response = await wreqFetch(PINNED_URL, { transport, timeout: 10_000 });
+
+      assert.equal(response.status, 200);
+    } finally {
+      await transport.close();
+    }
+  });
+
+  test("accepts a bare IP address without a port", async () => {
+    const transport = await createTransport({
+      browser: "chrome_142",
+      insecure: true,
+      resolve: { [PINNED_HOST]: "127.0.0.1" },
+    });
+
+    try {
+      const response = await wreqFetch(PINNED_URL, { transport, timeout: 10_000 });
+
+      assert.equal(response.status, 200);
+    } finally {
+      await transport.close();
+    }
+  });
+
+  test("fails without an override because the host cannot be resolved", async () => {
+    await assert.rejects(
+      wreqFetch(PINNED_URL, { browser: "chrome_142", insecure: true, timeout: 10_000 }),
+      "Request to an unresolvable host should fail without a resolve override",
+    );
+  });
+
+  test("rejects a malformed resolve address", async () => {
+    await assert.rejects(
+      createTransport({
+        browser: "chrome_142",
+        resolve: { [PINNED_HOST]: "not-an-ip-address" },
+      }),
+      "createTransport should reject an invalid resolve address",
+    );
+  });
+
+  test("keeps certificate verification enabled when pinning a matching host", async () => {
+    const transport = await createTransport({
+      browser: "chrome_142",
+      trustStore: "defaultPaths",
+      resolve: { localhost: `127.0.0.1:${CUSTOM_CA_PORT}` },
+    });
+
+    try {
+      const response = await wreqFetch(`https://localhost:${CUSTOM_CA_PORT}/json`, { transport, timeout: 10_000 });
+
+      assert.equal(response.status, 200);
+    } finally {
+      await transport.close();
+    }
+  });
+
+  test("validates the certificate against the request host, not the pinned address", async () => {
+    // The custom-CA cert covers only localhost. Pinning an unrelated host to that
+    // server reaches the pinned address, but verification runs against the request
+    // host's SNI and must fail.
+    const transport = await createTransport({
+      browser: "chrome_142",
+      trustStore: "defaultPaths",
+      resolve: { [PINNED_HOST]: `127.0.0.1:${CUSTOM_CA_PORT}` },
+    });
+
+    try {
+      await assert.rejects(
+        wreqFetch(`https://${PINNED_HOST}:${CUSTOM_CA_PORT}/json`, { transport, timeout: 10_000 }),
+        "certificate verification should fail for a host the certificate does not cover",
+      );
+    } finally {
+      await transport.close();
+    }
+  });
+
+  test("rejects a resolve value that is not an object", async () => {
+    await assert.rejects(
+      createTransport({
+        browser: "chrome_142",
+        resolve: "127.0.0.1" as unknown as Record<string, string>,
+      }),
+      "createTransport should reject a non-object resolve",
+    );
+  });
+
+  test("rejects an empty address list for a host", async () => {
+    await assert.rejects(
+      createTransport({
+        browser: "chrome_142",
+        resolve: { [PINNED_HOST]: [] },
+      }),
+      "createTransport should reject an empty address list",
+    );
+  });
+
+  test("rejects a non-string resolve address", async () => {
+    await assert.rejects(
+      createTransport({
+        browser: "chrome_142",
+        resolve: { [PINNED_HOST]: [123 as unknown as string] },
+      }),
+      "createTransport should reject a non-string address",
+    );
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,26 @@ export type TlsVersion = "1.0" | "1.1" | "1.2" | "1.3" | "TLS1.0" | "TLS1.1" | "
 export type Http2PseudoHeaderId = "Method" | "Scheme" | "Authority" | "Path" | "Protocol";
 export type TrustStoreMode = "combined" | "mozilla" | "defaultPaths";
 
+/**
+ * Overrides DNS resolution for specific hosts.
+ *
+ * Each key is a hostname and each value is one address, or an array of fallback addresses,
+ * written as `ip` or `ip:port`. Following reqwest/wreq semantics the port is optional and ignored,
+ * the request URL's port is always used.
+ *
+ * Useful for pinning a host to an address you have already resolved and vetted
+ * (for example to enforce SSRF protection), split-horizon DNS, or testing
+ * against a local server under a real hostname.
+ *
+ * @example
+ * ```typescript
+ * const transport = await createTransport({
+ *   resolve: { "example.com": "93.184.216.34" },
+ * });
+ * ```
+ */
+export type ResolveMap = Record<string, string | string[]>;
+
 export type Http2SettingId =
   | "HeaderTableSize"
   | "EnablePush"
@@ -538,6 +558,11 @@ export interface CreateTransportOptions {
    * @default "combined"
    */
   trustStore?: TrustStoreMode;
+
+  /**
+   * Override DNS resolution for specific hosts. See {@link ResolveMap}.
+   */
+  resolve?: ResolveMap;
 
   /**
    * Idle timeout for pooled connections (ms).

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -94,6 +94,7 @@ interface NativeTransportOptions {
   proxy?: string;
   insecure?: boolean;
   trustStore?: TrustStoreMode;
+  resolve?: Record<string, string | string[]>;
   poolIdleTimeout?: number;
   poolMaxIdlePerHost?: number;
   poolMaxSize?: number;
@@ -1786,6 +1787,26 @@ function validatePositiveInteger(value: number, label: string): void {
   }
 }
 
+function validateResolve(resolve: unknown): void {
+  if (typeof resolve !== "object" || resolve === null || Array.isArray(resolve)) {
+    throw new RequestError("resolve must be an object mapping hosts to addresses");
+  }
+
+  for (const [host, value] of Object.entries(resolve)) {
+    const addresses = Array.isArray(value) ? value : [value];
+
+    if (addresses.length === 0) {
+      throw new RequestError(`resolve['${host}'] must provide at least one address`);
+    }
+
+    for (const address of addresses) {
+      if (typeof address !== "string" || address.trim() === "") {
+        throw new RequestError(`resolve['${host}'] addresses must be non-empty strings`);
+      }
+    }
+  }
+}
+
 function validateIntegerInRange(value: number, min: number, max: number, label: string): void {
   validateNonNegativeInteger(value, label);
   if (value < min || value > max) {
@@ -2615,6 +2636,10 @@ export async function createTransport(options?: CreateTransportOptions): Promise
   const mode = resolveEmulationMode(options?.browser, options?.os, options?.emulation);
   validateTrustStore(options?.trustStore);
 
+  if (options?.resolve !== undefined) {
+    validateResolve(options.resolve);
+  }
+
   if (options?.poolIdleTimeout !== undefined) {
     validatePositiveNumber(options.poolIdleTimeout, "poolIdleTimeout");
   }
@@ -2636,6 +2661,7 @@ export async function createTransport(options?: CreateTransportOptions): Promise
       ...(options?.proxy !== undefined && { proxy: options.proxy }),
       ...(options?.insecure !== undefined && { insecure: options.insecure }),
       trustStore: options?.trustStore ?? DEFAULT_TRUST_STORE,
+      ...(options?.resolve !== undefined && { resolve: options.resolve }),
       ...(options?.poolIdleTimeout !== undefined && { poolIdleTimeout: options.poolIdleTimeout }),
       ...(options?.poolMaxIdlePerHost !== undefined && { poolMaxIdlePerHost: options.poolMaxIdlePerHost }),
       ...(options?.poolMaxSize !== undefined && { poolMaxSize: options.poolMaxSize }),


### PR DESCRIPTION
This PR adds a `resolve` option to `createTransport` so you can force a hostname to use a specific address instead of relying on system DNS. You can map a host to an `ip` or `ip:port`, or even provide a list of addresses as fallbacks. Under the hood it just uses `wreq`’s `ClientBuilder::resolve_to_addrs`.

The main reason I needed this is SSRF protection. I want to resolve the hostname myself, make sure the IP isn’t internal or private, and only then connect. If the client resolves it again on its own, there’s a window where it could end up hitting a different address due to DNS rebinding. With `resolve`, I can pass in the exact IP I already checked, so the client only connects there and doesn’t try to look it up again.

It’s also useful for things like split horizon DNS or testing against a local server while still using a real hostname.