### PR TITLE
feat: add getEmulationHeaders() to read a profile's default headers

### DIFF
--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -22,6 +22,7 @@ import {
   // Utilities
   getProfiles,
   getOperatingSystems,
+  getEmulationHeaders,
   
   // Classes
   Headers,
@@ -48,6 +49,7 @@ import {
 | [`websocket()`](/api-reference/websocket) | Connect to WebSocket servers |
 | [`getProfiles()`](/api-reference/utilities#getprofiles) | List available browser profiles |
 | [`getOperatingSystems()`](/api-reference/utilities#getoperatingsystems) | List available operating systems |
+| [`getEmulationHeaders()`](/api-reference/utilities#getemulationheaders) | Read the headers a browser profile injects |
 
 ## TypeScript support
 

--- a/docs/api-reference/utilities.mdx
+++ b/docs/api-reference/utilities.mdx
@@ -86,6 +86,54 @@ const mobileResponse = await fetch('https://example.com', {
 
 ---
 
+## getEmulationHeaders()
+
+Get the headers a browser profile injects into every request, without sending one.
+
+### Signature
+
+```typescript
+function getEmulationHeaders(browser?: BrowserProfile, os?: EmulationOS): Headers
+```
+
+Both arguments default to the same profile and OS as [`fetch`](/api-reference/fetch).
+
+### Returns
+
+A `Headers` instance holding the profile's headers, in the profile's own order and casing.
+
+Transport-level headers are not included: `Host`, `Connection`, `Content-Length`, and
+`Accept-Encoding` are added per request rather than by the emulation profile.
+
+### Example
+
+```typescript
+import { getEmulationHeaders } from 'wreq-js';
+
+const defaults = getEmulationHeaders('firefox_147');
+console.log(defaults.get('user-agent'));
+// Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:147.0) Gecko/20100101 Firefox/147.0
+```
+
+### Reusing a profile's User-Agent
+
+Passing a header through `headers` replaces the profile's matching header and leaves the
+rest of the fingerprint intact, so read the value first when you want to build on it.
+
+```typescript
+import { fetch, getEmulationHeaders } from 'wreq-js';
+
+const userAgent = getEmulationHeaders('firefox_147', 'windows').get('user-agent');
+
+const response = await fetch('https://example.com', {
+  browser: 'firefox_147',
+  os: 'windows',
+  headers: { 'X-Forwarded-User-Agent': userAgent ?? '' },
+});
+```
+
+---
+
 ## Headers
 
 The `Headers` class for working with HTTP headers.

--- a/rust/src/custom_emulation.rs
+++ b/rust/src/custom_emulation.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::time::Duration;
 use wreq::{
     Emulation as WreqEmulation, EmulationFactory,
-    header::{HeaderMap, HeaderName, HeaderValue, OrigHeaderMap},
+    header::{HeaderMap, HeaderName, HeaderValue, OrigHeaderMap, OrigHeaderName},
     http1::Http1Options,
     http2::{
         ExperimentalSettings, Http2Options, Priorities, Priority, PseudoId, PseudoOrder, Setting,
@@ -222,6 +222,45 @@ pub fn resolve_preset_emulation(
     }
 
     Ok(emulation)
+}
+
+/// Read-only view of the headers a preset profile injects into every request,
+/// in the profile's own order and with its original casing.
+///
+/// Lets callers inspect a profile (e.g. read its User-Agent) without sending a
+/// request; nothing here touches the request path.
+pub fn preset_emulation_headers(
+    browser: BrowserEmulation,
+    os: BrowserEmulationOS,
+) -> Result<Vec<(String, String)>> {
+    let mut emulation = resolve_preset_emulation(browser, os, None)?;
+    let orig_headers = emulation.orig_headers_mut().clone();
+    let mut headers = emulation.headers_mut().clone();
+
+    let mut resolved = Vec::with_capacity(headers.len());
+
+    // `OrigHeaderMap` keeps insertion order and original casing, `HeaderMap` keeps
+    // neither, so drain the ordered names first and let the rest follow.
+    for (name, orig_name) in orig_headers.iter() {
+        for value in headers.get_all(name) {
+            resolved.push((decode_header_name(orig_name), decode_header_value(value)));
+        }
+        headers.remove(name);
+    }
+
+    for (name, value) in headers.iter() {
+        resolved.push((name.as_str().to_owned(), decode_header_value(value)));
+    }
+
+    Ok(resolved)
+}
+
+fn decode_header_name(name: &OrigHeaderName) -> String {
+    String::from_utf8_lossy(name.as_ref()).into_owned()
+}
+
+fn decode_header_value(value: &HeaderValue) -> String {
+    String::from_utf8_lossy(value.as_bytes()).into_owned()
 }
 
 pub fn resolve_custom_emulation(emulation_json: &str) -> Result<WreqEmulation> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -759,6 +759,33 @@ fn get_profiles(mut cx: FunctionContext) -> JsResult<JsArray> {
     Ok(js_array)
 }
 
+// Get the headers a browser profile injects, without sending a request
+fn get_emulation_headers(mut cx: FunctionContext) -> JsResult<JsArray> {
+    let browser_str = cx.argument::<JsString>(0)?.value(&mut cx);
+    let os_str = cx.argument::<JsString>(1)?.value(&mut cx);
+
+    let headers = match custom_emulation::preset_emulation_headers(
+        parse_emulation(&browser_str),
+        parse_emulation_os(&os_str),
+    ) {
+        Ok(headers) => headers,
+        Err(err) => return cx.throw_error(format!("{err:#}")),
+    };
+
+    let js_array = JsArray::new(&mut cx, headers.len());
+
+    for (i, (name, value)) in headers.iter().enumerate() {
+        let entry = cx.empty_array();
+        let name_str = cx.string(name);
+        let value_str = cx.string(value);
+        entry.set(&mut cx, 0, name_str)?;
+        entry.set(&mut cx, 1, value_str)?;
+        js_array.set(&mut cx, i as u32, entry)?;
+    }
+
+    Ok(js_array)
+}
+
 // Get list of available operating systems for emulation
 fn get_operating_systems(mut cx: FunctionContext) -> JsResult<JsArray> {
     let js_array = cx.empty_array();
@@ -1689,6 +1716,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("cancelBody", cancel_body_stream)?;
     cx.export_function("getProfiles", get_profiles)?;
     cx.export_function("getOperatingSystems", get_operating_systems)?;
+    cx.export_function("getEmulationHeaders", get_emulation_headers)?;
     cx.export_function("createSession", create_session)?;
     cx.export_function("clearSession", clear_session)?;
     cx.export_function("dropSession", drop_session)?;

--- a/src/test/http/profiles.spec.ts
+++ b/src/test/http/profiles.spec.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
-import type { BrowserProfile } from "../../wreq-js.js";
-import { getProfiles, RequestError, fetch as wreqFetch } from "../../wreq-js.js";
+import type { BrowserProfile, EmulationOS } from "../../wreq-js.js";
+import { getEmulationHeaders, getProfiles, RequestError, fetch as wreqFetch } from "../../wreq-js.js";
 import { httpUrl } from "../helpers/http.js";
+
+// Added by the client rather than the emulation profile, so they are not part of its header set.
+const TRANSPORT_HEADERS = new Set(["host", "connection", "content-length", "accept-encoding"]);
 
 describe("HTTP profiles", () => {
   test("returns available browser profiles", () => {
@@ -29,5 +32,49 @@ describe("HTTP profiles", () => {
       (error: unknown) => error instanceof RequestError,
       "Should reject invalid browser profiles",
     );
+  });
+
+  test("exposes the headers a profile injects", () => {
+    const headers = getEmulationHeaders("firefox_147");
+
+    assert.ok(headers.get("user-agent")?.includes("Firefox/147"), "Should expose the profile's User-Agent");
+    assert.ok(headers.get("accept"), "Should expose the profile's Accept header");
+  });
+
+  test("emulation headers follow the requested operating system", () => {
+    const macos = getEmulationHeaders("chrome_142", "macos").get("user-agent");
+    const windows = getEmulationHeaders("chrome_142", "windows").get("user-agent");
+
+    assert.ok(macos?.includes("Mac OS X"), "macOS profile should report a macOS User-Agent");
+    assert.ok(windows?.includes("Windows"), "Windows profile should report a Windows User-Agent");
+    assert.notStrictEqual(macos, windows);
+  });
+
+  test("emulation headers match what the profile actually sends", async () => {
+    for (const browser of ["firefox_147", "chrome_142", "safari_18"] as BrowserProfile[]) {
+      const response = await wreqFetch(httpUrl("/headers"), { browser, timeout: 10_000 });
+      const body = await response.json<{ rawHeaders: string[] }>();
+
+      const sent = body.rawHeaders
+        .filter((_, index) => index % 2 === 0)
+        .map((name) => name.toLowerCase())
+        .filter((name) => !TRANSPORT_HEADERS.has(name));
+      const declared = [...getEmulationHeaders(browser)].map(([name]) => name.toLowerCase());
+
+      // Header order is part of the fingerprint, so compare the sequence, not just the set.
+      assert.deepStrictEqual(declared, sent, `${browser} should declare the headers it sends, in order`);
+    }
+  });
+
+  test("returns a fresh Headers instance per call", () => {
+    const first = getEmulationHeaders("chrome_142");
+    first.set("user-agent", "mutated");
+
+    assert.notStrictEqual(getEmulationHeaders("chrome_142").get("user-agent"), "mutated");
+  });
+
+  test("rejects invalid profiles and operating systems", () => {
+    assert.throws(() => getEmulationHeaders("nonexistent_browser" as BrowserProfile), RequestError);
+    assert.throws(() => getEmulationHeaders("chrome_142", "solaris" as EmulationOS), RequestError);
   });
 });

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -145,12 +145,14 @@ let nativeBinding: {
   createTransport: (options: NativeTransportOptions) => string;
   dropTransport: (transportId: string) => void;
   getOperatingSystems?: () => string[];
+  getEmulationHeaders?: (browser: string, os: string) => HeaderTuple[];
 };
 
 let cachedProfiles: BrowserProfile[] | undefined;
 let cachedProfileSet: Set<string> | undefined;
 let cachedOperatingSystems: EmulationOS[] | undefined;
 let cachedOperatingSystemSet: Set<string> | undefined;
+const cachedEmulationHeaders = new Map<string, HeaderTuple[]>();
 
 function detectLibc(): "gnu" | "musl" | undefined {
   if (process.platform !== "linux") {
@@ -2896,6 +2898,55 @@ function getOperatingSystemSet(): Set<string> {
   }
 
   return cachedOperatingSystemSet;
+}
+
+/**
+ * Get the headers a browser profile injects into every request, without sending one.
+ *
+ * Returns the emulation's own headers in profile order and original casing. Pass any of
+ * these back through `headers` to override them for a request; the rest of the profile
+ * stays intact.
+ *
+ * @param browser - Browser profile to inspect (defaults to the same profile as {@link fetch})
+ * @param os - Operating system to emulate (defaults to the same OS as {@link fetch})
+ * @returns A {@link Headers} instance holding the profile's default headers
+ *
+ * @example
+ * ```typescript
+ * import { fetch, getEmulationHeaders } from 'wreq-js';
+ *
+ * const defaults = getEmulationHeaders('firefox_147');
+ * const userAgent = defaults.get('user-agent');
+ *
+ * // Reuse the profile's User-Agent while sending your own headers
+ * await fetch('https://example.com', {
+ *   browser: 'firefox_147',
+ *   headers: { 'X-Client': `proxy (${userAgent})` },
+ * });
+ * ```
+ */
+export function getEmulationHeaders(browser?: BrowserProfile, os?: EmulationOS): Headers {
+  validateBrowserProfile(browser);
+  validateOperatingSystem(os);
+
+  const resolvedBrowser = browser ?? DEFAULT_BROWSER;
+  const resolvedOs = os ?? DEFAULT_OS;
+  const cacheKey = `${resolvedBrowser} ${resolvedOs}`;
+
+  let tuples = cachedEmulationHeaders.get(cacheKey);
+  if (!tuples) {
+    const readEmulationHeaders = nativeBinding.getEmulationHeaders;
+    if (!readEmulationHeaders) {
+      throw new RequestError("getEmulationHeaders is not available in this build of the native addon");
+    }
+
+    // Emulation headers are fixed per profile, so resolve the emulation once.
+    tuples = readEmulationHeaders(resolvedBrowser, resolvedOs);
+    cachedEmulationHeaders.set(cacheKey, tuples);
+  }
+
+  // Fresh instance per call - callers must not be able to mutate the cache.
+  return new Headers(tuples);
 }
 
 /**


### PR DESCRIPTION
## What this does

`getEmulationHeaders(browser?, os?)` returns the headers a profile injects, without sending a request.

```js
import { getEmulationHeaders } from "wreq-js";

const defaults = getEmulationHeaders("firefox_147");
defaults.get("user-agent");
// Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:147.0) Gecko/20100101 Firefox/147.0
```

Both arguments default to the same profile and OS as `fetch()`. You get back a `Headers` in the profile's own order and casing.

## Why

#145 asked for two separate things. The alias half (`browser: "firefox"` resolving to the newest Firefox) stays declined: an alias that moves means the same pinned version of this library starts sending a different TLS fingerprint after an unrelated patch bump.

The other half never got addressed:

> it would be greatly appreciated if there was a method accessible that outputs the `defaultHeaders`. This way, I could get the user-agent from it while passing my other headers

That is read access, not override. `headers` already replaces a profile's header by name, which is why #150 was closed as redundant, but there is currently no way to see what the profile sends in the first place. `getProfiles()` and `getOperatingSystems()` only return names, and nothing header related is exported from the native side.

## Implementation

Rust: `preset_emulation_headers()` resolves the preset emulation and reads `headers_mut()` plus `orig_headers_mut()`. That second map is the important part, since `HeaderMap` preserves neither insertion order nor original casing and `OrigHeaderMap` preserves both. Ordered names get drained first, anything left over follows. Same shape as wreq's own `sort_headers_for_each`, which is `pub(crate)` so we can't just call it.

JS: results are cached per `(browser, os)` because a profile's headers are fixed, but every call builds a fresh `Headers` so callers can't mutate the cache.

The request path is untouched. This is purely additive and read only.

## Ordering is tested, not assumed

Header order is part of the fingerprint, so returning a plausible looking order that doesn't match the wire would be worse than not shipping this at all. A test compares the declared sequence against `req.rawHeaders` from the local test server, using three profiles whose real orders differ quite a bit:

```
firefox_147: te, user-agent, accept, accept-language, sec-fetch-dest, sec-fetch-mode, sec-fetch-site, priority
chrome_142:  sec-ch-ua, sec-ch-ua-mobile, sec-ch-ua-platform, user-agent, sec-fetch-dest, sec-fetch-mode, sec-fetch-site, accept, accept-language, priority
safari_18:   sec-fetch-dest, user-agent, accept, sec-fetch-site, sec-fetch-mode, accept-language, priority
```

`Host`, `Connection`, `Content-Length` and `Accept-Encoding` are excluded, since the client adds those per request rather than the emulation profile. That's documented on the function.

## Changes

| File | Change |
|---|---|
| `rust/src/custom_emulation.rs` | `preset_emulation_headers()` plus header name/value decoding |
| `rust/src/lib.rs` | `getEmulationHeaders` Neon export |
| `src/wreq-js.ts` | `getEmulationHeaders()`, native binding decl, per-profile cache |
| `src/test/http/profiles.spec.ts` | 5 new tests |
| `docs/api-reference/{utilities,overview}.mdx` | API reference entry |

## Testing

```
179/179 pass (full suite with local test server)
```

New tests: exposes a profile's User-Agent, follows the requested OS, declared headers match what is sent in order, returns a fresh `Headers` per call, rejects invalid profiles and operating systems.

No new clippy warnings (8 before, 8 after), biome clean, `tsc --noEmit` clean.

Closes #145
