### PR TITLE
build(linux-gnu): build native module in manylinux_2_28 containers to support glibc < 2.34

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,14 +204,94 @@ jobs:
         run: ${{ matrix.settings.build }}
 
       - name: Build native module (other non-musl targets)
-        if: runner.os != 'Windows' && matrix.settings.target != 'x86_64-unknown-linux-musl' && matrix.settings.target != 'aarch64-unknown-linux-musl'
+        # Only macOS remains on the host runner. The linux-*-gnu targets are
+        # built inside manylinux_2_28 containers below to pin a portable
+        # glibc baseline (glibc 2.28). Building on the ubuntu-24.04 runner
+        # (glibc 2.39) produces binaries that require GLIBC_2.33/2.34 and fail
+        # to load on older glibc (e.g. 2.31 on CentOS/RHEL-family). See #182.
+        if: runner.os == 'macOS'
         run: ${{ matrix.settings.build }}
 
+      - name: Build native module (x86_64-gnu target, manylinux_2_28)
+        if: matrix.settings.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          docker run --rm \
+            -v "$PWD:/app" \
+            -w /app \
+            quay.io/pypa/manylinux_2_28_x86_64 \
+            sh -lc '
+              set -eux
+              # manylinux_2_28 ships gcc-toolset / cmake / perl / python3, enough
+              # for BoringSSL (btls) to build with gcc. We avoid the EPEL repo
+              # (EPEL 8 is EOL with flaky mirrors); clang-devel 17 is available
+              # from AppStream and provides libclang.so + clang builtin headers
+              # (incl. stddef.h) needed by bindgen (btls-sys FFI generation).
+              dnf install -y --disablerepo=epel git make clang-devel
+              export LIBCLANG_PATH=/usr/lib64
+              # Rust toolchain (manylinux images do not ship Rust).
+              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+              source "$HOME/.cargo/env"
+              rustup target add x86_64-unknown-linux-gnu
+              # Node.js is required by @napi-rs/cli (napi build).
+              curl -fsSL https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-x64.tar.xz \
+                | tar -xJ -C /usr/local --strip-components=1
+              npm ci --ignore-scripts
+              npm run build:rust -- --target x86_64-unknown-linux-gnu
+            '
+
+      - name: Build native module (aarch64-gnu target, manylinux_2_28)
+        if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          docker run --rm \
+            -v "$PWD:/app" \
+            -w /app \
+            quay.io/pypa/manylinux_2_28_aarch64 \
+            sh -lc '
+              set -eux
+              dnf install -y --disablerepo=epel git make clang-devel
+              export LIBCLANG_PATH=/usr/lib64
+              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+              source "$HOME/.cargo/env"
+              rustup target add aarch64-unknown-linux-gnu
+              curl -fsSL https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-arm64.tar.xz \
+                | tar -xJ -C /usr/local --strip-components=1
+              npm ci --ignore-scripts
+              npm run build:rust -- --target aarch64-unknown-linux-gnu
+            '
+
       - name: Smoke test native addon
-        if: matrix.settings.target != 'x86_64-unknown-linux-musl' && matrix.settings.target != 'aarch64-unknown-linux-musl'
+        if: runner.os == 'macOS'
         env:
           WREQ_TARGET: ${{ matrix.settings.target }}
         run: node scripts/smoke-native.cjs
+
+      - name: Smoke test native addon (x86_64-gnu, manylinux_2_28)
+        if: matrix.settings.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          docker run --rm \
+            -e WREQ_PLATFORM_ARCH=linux-x64-gnu \
+            -v "$PWD:/app" \
+            -w /app \
+            quay.io/pypa/manylinux_2_28_x86_64 \
+            sh -lc '
+              curl -fsSL https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-x64.tar.xz \
+                | tar -xJ -C /usr/local --strip-components=1
+              node scripts/smoke-native.cjs
+            '
+
+      - name: Smoke test native addon (aarch64-gnu, manylinux_2_28)
+        if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          docker run --rm \
+            -e WREQ_PLATFORM_ARCH=linux-arm64-gnu \
+            -v "$PWD:/app" \
+            -w /app \
+            quay.io/pypa/manylinux_2_28_aarch64 \
+            sh -lc '
+              curl -fsSL https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-arm64.tar.xz \
+                | tar -xJ -C /usr/local --strip-components=1
+              node scripts/smoke-native.cjs
+            '
 
       - name: Smoke test native addon (musl)
         if: matrix.settings.target == 'x86_64-unknown-linux-musl'


### PR DESCRIPTION
## Problem

The prebuilt `linux-x64-gnu` and `linux-arm64-gnu` native modules shipped in recent releases fail to load on systems with glibc < 2.34 (e.g. glibc 2.31 on CentOS/RHEL-family distros still widely used in enterprise environments). This breaks any package that depends on `wreq-js` on such hosts — for example the `pi-search` extension cannot even start `pi`:

```
$ pi
Error: Failed to load extension ".../pi-search/index.ts": Failed to load extension:
Failed to load native module for linux-x64-gnu. Tried: ../rust/wreq-js.linux-x64-gnu.node
and ../rust/wreq-js.node. Make sure the package is installed correctly and the native
module is built for your platform.
```

## Root cause

The `linux-*-gnu` targets are built directly on the `ubuntu-24.04` runner (glibc 2.39). The resulting `.node` files therefore record `GLIBC_2.33` / `GLIBC_2.34` version requirements:

```
$ objdump -T rust/wreq-js.linux-x64-gnu.node | grep -E 'GLIBC_2\.3[34]'
 GLIBC_2.34  dlsym / dlopen / dlerror / dlclose
 GLIBC_2.34  pthread_create / pthread_join / pthread_rwlock_* / pthread_once / ...
 GLIBC_2.33  stat64 / fstat64 / stat
```

On glibc 2.31 these symbols exist functionally, but the dynamic loader rejects the binary because the `GLIBC_2.33`/`GLIBC_2.34` version tags are absent. The `linux-x64-musl` build is not a valid fallback on a glibc host (different ABI), so users on glibc 2.31 have no working prebuilt at all. See #182.

This is the standard "built on too-new glibc" portability problem. The pthread/dl symbols landed in `GLIBC_2.34` because glibc 2.34 merged libpthread/libdl into libc.

## Fix

Build both `linux-*-gnu` targets inside **`manylinux_2_28`** containers (glibc 2.28 baseline, based on CentOS 8) instead of on the host runner, mirroring the existing musl Docker build approach. `manylinux_2_28` is chosen over `manylinux2014` (glibc 2.17) as a pragmatic baseline: it covers CentOS 8+, RHEL 8+, Ubuntu 20.04+, Debian 11+, etc., while keeping a modern enough toolchain for BoringSSL (`btls`) to build without the extra friction of CentOS 7's older compiler.

Smoke tests for the GNU targets are also run inside the `manylinux_2_28` container, so the compatibility baseline is actually exercised in CI rather than being masked by the runner's glibc 2.39.

macOS and the existing musl/Windows build paths are unchanged.

## Changes

Only `.github/workflows/build.yml`:

- `Build native module (other non-musl targets)` is now gated to `runner.os == 'macOS'` (was: everything non-Windows/non-musl, which included the GNU targets on the host runner).
- New `Build native module (x86_64-gnu target, manylinux_2_28)` step: runs the build in `quay.io/pypa/manylinux_2_28_x86_64`, installs Rust (rustup) + Node + cmake/git/perl/clang-devel (needed by `btls`/BoringSSL), then `npm run build:rust -- --target x86_64-unknown-linux-gnu`.
- New `Build native module (aarch64-gnu target, manylinux_2_28)` step: same for `manylinux_2_28_aarch64`.
- `Smoke test native addon` (host) is now gated to `runner.os == 'macOS'`.
- New `Smoke test native addon (x86_64-gnu, manylinux_2_28)` and `(aarch64-gnu, manylinux_2_28)` steps that run `scripts/smoke-native.cjs` inside the corresponding manylinux container with `WREQ_PLATFORM_ARCH` set.

## Verification

Because `build.yml` only triggers on `release` / `workflow_dispatch` (not on PRs), this change is **not** exercised by the PR's own CI. To validate it before merging, I will trigger `workflow_dispatch` on my fork (`micookie2/wreq-js`) and report back here with:

1. The `manylinux_2_28` build completing green for both GNU targets.
2. `objdump -T` of the produced `wreq-js.linux-x64-gnu.node` showing **no** `GLIBC_2.33`/`GLIBC_2.34` symbols (expected max around `GLIBC_2.28`).
3. A successful `node -e "require('.../wreq-js.linux-x64-gnu.node')"` on a glibc 2.31 host (the reporter's actual environment).

I'll attach the run URL and the command outputs to this PR once the fork run finishes.

## Notes for the maintainer

- `manylinux_2_28` images are CentOS 8 based and use `dnf` (the steps use `dnf install`). If you'd prefer the wider compatibility of `manylinux2014` (glibc 2.17, `yum`-based), the change is a one-line image swap plus `dnf`→`yum` — happy to switch if you prefer.
- Node is pinned to v22.11.0 inside the container only because `@napi-rs/cli` needs `node` on `PATH` for `napi build`; the published artifact is independent of this Node version.
- The BoringSSL (`btls`) build is the main risk on the manylinux toolchain; if it fails I'll adjust the installed packages accordingly.

Ref: #182
