### PR TITLE
fix: split native binaries into per-platform packages (57 MB -> 674 KB)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,8 +358,28 @@ jobs:
           echo "Collected binaries:"
           ls -la rust/*.node
 
+      - name: Copy artifacts to platform packages
+        run: |
+          cp rust/wreq-js.darwin-x64.node npm/wreq-js-darwin-x64/
+          cp rust/wreq-js.darwin-arm64.node npm/wreq-js-darwin-arm64/
+          cp rust/wreq-js.linux-x64-gnu.node npm/wreq-js-linux-x64-gnu/
+          cp rust/wreq-js.linux-arm64-gnu.node npm/wreq-js-linux-arm64-gnu/
+          cp rust/wreq-js.linux-x64-musl.node npm/wreq-js-linux-x64-musl/
+          cp rust/wreq-js.linux-arm64-musl.node npm/wreq-js-linux-arm64-musl/
+          cp rust/wreq-js.win32-x64-msvc.node npm/wreq-js-win32-x64-msvc/
+
       - name: Build TypeScript
         run: npm run build:ts
+
+      - name: Publish platform packages with trusted publishing
+        run: |
+          npm publish ./npm/wreq-js-darwin-x64 --provenance --access public
+          npm publish ./npm/wreq-js-darwin-arm64 --provenance --access public
+          npm publish ./npm/wreq-js-linux-x64-gnu --provenance --access public
+          npm publish ./npm/wreq-js-linux-arm64-gnu --provenance --access public
+          npm publish ./npm/wreq-js-linux-x64-musl --provenance --access public
+          npm publish ./npm/wreq-js-linux-arm64-musl --provenance --access public
+          npm publish ./npm/wreq-js-win32-x64-msvc --provenance --access public
 
       - name: Publish to npm with trusted publishing
         run: npm publish --provenance --access public

--- a/npm/wreq-js-darwin-arm64/package.json
+++ b/npm/wreq-js-darwin-arm64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wreq-js-darwin-arm64",
+  "version": "3.0.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "wreq-js.darwin-arm64.node",
+  "files": [
+    "wreq-js.darwin-arm64.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/npm/wreq-js-darwin-x64/package.json
+++ b/npm/wreq-js-darwin-x64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wreq-js-darwin-x64",
+  "version": "3.0.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "wreq-js.darwin-x64.node",
+  "files": [
+    "wreq-js.darwin-x64.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/npm/wreq-js-linux-arm64-gnu/package.json
+++ b/npm/wreq-js-linux-arm64-gnu/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "wreq-js-linux-arm64-gnu",
+  "version": "3.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "wreq-js.linux-arm64-gnu.node",
+  "files": [
+    "wreq-js.linux-arm64-gnu.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/npm/wreq-js-linux-arm64-musl/package.json
+++ b/npm/wreq-js-linux-arm64-musl/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "wreq-js-linux-arm64-musl",
+  "version": "3.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "wreq-js.linux-arm64-musl.node",
+  "files": [
+    "wreq-js.linux-arm64-musl.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/npm/wreq-js-linux-x64-gnu/package.json
+++ b/npm/wreq-js-linux-x64-gnu/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "wreq-js-linux-x64-gnu",
+  "version": "3.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "wreq-js.linux-x64-gnu.node",
+  "files": [
+    "wreq-js.linux-x64-gnu.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/npm/wreq-js-linux-x64-musl/package.json
+++ b/npm/wreq-js-linux-x64-musl/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "wreq-js-linux-x64-musl",
+  "version": "3.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "wreq-js.linux-x64-musl.node",
+  "files": [
+    "wreq-js.linux-x64-musl.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/npm/wreq-js-win32-x64-msvc/package.json
+++ b/npm/wreq-js-win32-x64-msvc/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wreq-js-win32-x64-msvc",
+  "version": "3.0.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "wreq-js.win32-x64-msvc.node",
+  "files": [
+    "wreq-js.win32-x64-msvc.node"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sqdshguy/wreq-js.git"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,15 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "wreq-js-darwin-arm64": "3.0.0",
+        "wreq-js-darwin-x64": "3.0.0",
+        "wreq-js-linux-arm64-gnu": "3.0.0",
+        "wreq-js-linux-arm64-musl": "3.0.0",
+        "wreq-js-linux-x64-gnu": "3.0.0",
+        "wreq-js-linux-x64-musl": "3.0.0",
+        "wreq-js-win32-x64-msvc": "3.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -4502,6 +4511,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wreq-js-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/wreq-js-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/wreq-js-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/wreq-js-linux-arm64-musl": {
+      "optional": true
+    },
+    "node_modules/wreq-js-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/wreq-js-linux-x64-musl": {
+      "optional": true
+    },
+    "node_modules/wreq-js-win32-x64-msvc": {
+      "optional": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -105,9 +105,17 @@
     "arm64"
   ],
   "files": [
-    "dist",
-    "rust/*.node"
+    "dist"
   ],
+  "optionalDependencies": {
+    "wreq-js-darwin-arm64": "3.0.0",
+    "wreq-js-darwin-x64": "3.0.0",
+    "wreq-js-linux-arm64-gnu": "3.0.0",
+    "wreq-js-linux-arm64-musl": "3.0.0",
+    "wreq-js-linux-x64-gnu": "3.0.0",
+    "wreq-js-linux-x64-musl": "3.0.0",
+    "wreq-js-win32-x64-msvc": "3.0.0"
+  },
   "napi": {
     "binaryName": "wreq-js",
     "targets": [

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -189,13 +189,17 @@ function loadNativeBinding() {
       return require("../rust/wreq-js.darwin-x64.node");
     } catch {
       try {
-        return require("../rust/wreq-js.node");
+        return require("wreq-js-darwin-x64");
       } catch {
-        throw new Error(
-          "Failed to load native module for darwin-x64. " +
-            "Tried: ../rust/wreq-js.darwin-x64.node and ../rust/wreq-js.node. " +
-            "Make sure the package is installed correctly and the native module is built for your platform.",
-        );
+        try {
+          return require("../rust/wreq-js.node");
+        } catch {
+          throw new Error(
+            "Failed to load native module for darwin-x64. " +
+              "Tried: ../rust/wreq-js.darwin-x64.node, wreq-js-darwin-x64, and ../rust/wreq-js.node. " +
+              "Make sure the package is installed correctly and the native module is built for your platform.",
+          );
+        }
       }
     }
   }
@@ -205,13 +209,17 @@ function loadNativeBinding() {
       return require("../rust/wreq-js.darwin-arm64.node");
     } catch {
       try {
-        return require("../rust/wreq-js.node");
+        return require("wreq-js-darwin-arm64");
       } catch {
-        throw new Error(
-          "Failed to load native module for darwin-arm64. " +
-            "Tried: ../rust/wreq-js.darwin-arm64.node and ../rust/wreq-js.node. " +
-            "Make sure the package is installed correctly and the native module is built for your platform.",
-        );
+        try {
+          return require("../rust/wreq-js.node");
+        } catch {
+          throw new Error(
+            "Failed to load native module for darwin-arm64. " +
+              "Tried: ../rust/wreq-js.darwin-arm64.node, wreq-js-darwin-arm64, and ../rust/wreq-js.node. " +
+              "Make sure the package is installed correctly and the native module is built for your platform.",
+          );
+        }
       }
     }
   }
@@ -222,13 +230,17 @@ function loadNativeBinding() {
         return require("../rust/wreq-js.linux-x64-musl.node");
       } catch {
         try {
-          return require("../rust/wreq-js.node");
+          return require("wreq-js-linux-x64-musl");
         } catch {
-          throw new Error(
-            "Failed to load native module for linux-x64-musl. " +
-              "Tried: ../rust/wreq-js.linux-x64-musl.node and ../rust/wreq-js.node. " +
-              "Make sure the package is installed correctly and the native module is built for your platform.",
-          );
+          try {
+            return require("../rust/wreq-js.node");
+          } catch {
+            throw new Error(
+              "Failed to load native module for linux-x64-musl. " +
+                "Tried: ../rust/wreq-js.linux-x64-musl.node, wreq-js-linux-x64-musl, and ../rust/wreq-js.node. " +
+                "Make sure the package is installed correctly and the native module is built for your platform.",
+            );
+          }
         }
       }
     }
@@ -237,13 +249,17 @@ function loadNativeBinding() {
       return require("../rust/wreq-js.linux-x64-gnu.node");
     } catch {
       try {
-        return require("../rust/wreq-js.node");
+        return require("wreq-js-linux-x64-gnu");
       } catch {
-        throw new Error(
-          "Failed to load native module for linux-x64-gnu. " +
-            "Tried: ../rust/wreq-js.linux-x64-gnu.node and ../rust/wreq-js.node. " +
-            "Make sure the package is installed correctly and the native module is built for your platform.",
-        );
+        try {
+          return require("../rust/wreq-js.node");
+        } catch {
+          throw new Error(
+            "Failed to load native module for linux-x64-gnu. " +
+              "Tried: ../rust/wreq-js.linux-x64-gnu.node, wreq-js-linux-x64-gnu, and ../rust/wreq-js.node. " +
+              "Make sure the package is installed correctly and the native module is built for your platform.",
+          );
+        }
       }
     }
   }
@@ -254,13 +270,17 @@ function loadNativeBinding() {
         return require("../rust/wreq-js.linux-arm64-musl.node");
       } catch {
         try {
-          return require("../rust/wreq-js.node");
+          return require("wreq-js-linux-arm64-musl");
         } catch {
-          throw new Error(
-            "Failed to load native module for linux-arm64-musl. " +
-              "Tried: ../rust/wreq-js.linux-arm64-musl.node and ../rust/wreq-js.node. " +
-              "Make sure the package is installed correctly and the native module is built for your platform.",
-          );
+          try {
+            return require("../rust/wreq-js.node");
+          } catch {
+            throw new Error(
+              "Failed to load native module for linux-arm64-musl. " +
+                "Tried: ../rust/wreq-js.linux-arm64-musl.node, wreq-js-linux-arm64-musl, and ../rust/wreq-js.node. " +
+                "Make sure the package is installed correctly and the native module is built for your platform.",
+            );
+          }
         }
       }
     }
@@ -269,13 +289,17 @@ function loadNativeBinding() {
       return require("../rust/wreq-js.linux-arm64-gnu.node");
     } catch {
       try {
-        return require("../rust/wreq-js.node");
+        return require("wreq-js-linux-arm64-gnu");
       } catch {
-        throw new Error(
-          "Failed to load native module for linux-arm64-gnu. " +
-            "Tried: ../rust/wreq-js.linux-arm64-gnu.node and ../rust/wreq-js.node. " +
-            "Make sure the package is installed correctly and the native module is built for your platform.",
-        );
+        try {
+          return require("../rust/wreq-js.node");
+        } catch {
+          throw new Error(
+            "Failed to load native module for linux-arm64-gnu. " +
+              "Tried: ../rust/wreq-js.linux-arm64-gnu.node, wreq-js-linux-arm64-gnu, and ../rust/wreq-js.node. " +
+              "Make sure the package is installed correctly and the native module is built for your platform.",
+          );
+        }
       }
     }
   }
@@ -285,13 +309,17 @@ function loadNativeBinding() {
       return require("../rust/wreq-js.win32-x64-msvc.node");
     } catch {
       try {
-        return require("../rust/wreq-js.node");
+        return require("wreq-js-win32-x64-msvc");
       } catch {
-        throw new Error(
-          "Failed to load native module for win32-x64-msvc. " +
-            "Tried: ../rust/wreq-js.win32-x64-msvc.node and ../rust/wreq-js.node. " +
-            "Make sure the package is installed correctly and the native module is built for your platform.",
-        );
+        try {
+          return require("../rust/wreq-js.node");
+        } catch {
+          throw new Error(
+            "Failed to load native module for win32-x64-msvc. " +
+              "Tried: ../rust/wreq-js.win32-x64-msvc.node, wreq-js-win32-x64-msvc, and ../rust/wreq-js.node. " +
+              "Make sure the package is installed correctly and the native module is built for your platform.",
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
### Summary

Every install of `wreq-js` currently downloads all seven prebuilt binaries. `package.json` has `files: ["dist", "rust/*.node"]` and no `optionalDependencies`, so the published tarball carries every platform even though exactly one addon is ever loaded.

Measured on the published `wreq-js@3.0.0`: **57.0 MB unpacked, 15 files**. On linux-x64-gnu only `rust/wreq-js.linux-x64-gnu.node` (8.8 MB) is used; the other six are dead weight.

This PR moves the binaries into per-platform packages resolved by npm through `os`/`cpu`/`libc`, which is the standard napi-rs layout (`impit`, `@swc/core`, `esbuild` all ship this way).

### Result

```
root package   9,504,014 -> 674,070 bytes unpacked   (9 -> 8 files)
platform pkg   8,834,699 bytes unpacked, one addon
```

The 9.5 MB local baseline is this repo built with only the Linux x64 glibc addon present. Against the published 57.0 MB tarball the reduction is roughly 99%.

### What changed

- `npm/wreq-js-<platform>/package.json` for the seven targets already declared in `napi.targets`, each with `os`, `cpu`, `libc` where applicable.
- Root `optionalDependencies` lists all seven at the same version; `files` drops `rust/*.node`.
- `loadNativeBinding` gains a subpackage attempt in each of its seven branches.
- The existing `publish` job now publishes the platform packages before the root, keeping OIDC trusted publishing and `--provenance`. No `NPM_TOKEN` is introduced.

### Local-first resolution is preserved

Each branch tries `../rust/<platform>.node` **first**, then the subpackage, then the generic `../rust/wreq-js.node`, then throws. That order matters: `npm run build:rust` writes into `rust/`, and the `publish` job downloads CI artifacts into the same directory. Putting the subpackage first would have broken both.

Verified explicitly, not assumed:

- **Subpackage path** — copied the real addon into `node_modules/wreq-js-linux-x64-gnu/`, deleted every `rust/*.node`, required `dist/wreq-js.cjs`. Resolved to the subpackage.
- **Local-first** — restored `rust/wreq-js.linux-x64-gnu.node` and replaced the subpackage addon with a zero-byte file. Loading still succeeded, proving the local path wins before the broken subpackage is reached.
- `npm run build` passes.

The `Tried:` text in each error message now names all three candidates so a failure stays diagnosable.

### Notes

- Version is untouched at `3.0.0`; releases are yours to cut.
- No new dependencies, no changes to `src/generated-types.ts`, no restructuring of the `build_full` matrix (it already produces exactly the artifacts the platform packages need).
- One caveat I could not verify locally: I have no npm publish rights here, so the publish-order change (platform packages before root) is reasoned from the manifest rather than executed. Worth a look before the next release.

---

Context for why I care: we replaced `impit` with `wreq-js` in our provider SDK because it is the only JS client that reproduces the Safari 17 JA3 **and** HTTP/2 SETTINGS exactly, which an Akamai-protected upstream we work with checks. That SDK ships to ~38 Alpine containers, where the current 57 MB tarball is the one real cost. Thanks for building it.
