### PR TITLE
fix(scripts): require npm 12 in the platform package bootstrap

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -88,12 +88,19 @@ npm cannot configure a trusted publisher for a package that does not exist yet, 
 can work:
 
 ```bash
+npm install -g npm@latest                          # needs npm 12+, see below
 scripts/bootstrap-platform-packages.sh --dry-run   # inspect
 scripts/bootstrap-platform-packages.sh             # claim names + configure trusted publishing
 ```
 
 This is a one-time step run from a logged-in npm account with 2FA enabled. Every release
 after that is fully automated.
+
+npm 12 or later is required: npm 11 advertises `--allow-publish` in `npm trust github --help`
+but never defines the flag, so the call fails to parse, and since May 2026 the registry
+requires a trusted publisher to name at least one allowed action. The script checks this
+before it publishes anything. Log in interactively rather than with a granular access token —
+token-based auth that bypasses 2FA is not accepted for `npm trust`.
 
 ## Platform-Specific Notes
 

--- a/scripts/bootstrap-platform-packages.sh
+++ b/scripts/bootstrap-platform-packages.sh
@@ -31,6 +31,18 @@ if [[ ! -d npm ]]; then
   exit 1
 fi
 
+# npm 11 advertises --allow-publish in `npm trust github --help` but never
+# defines the flag, so it fails to parse; and since May 2026 the registry
+# requires a trusted publisher to name at least one allowed action, which
+# npm 11 cannot send. Fail early rather than half-way through the loop.
+npm_major=$(npm --version | cut -d. -f1)
+if [[ -z "$DRY_RUN" && "$npm_major" -lt 12 ]]; then
+  echo "npm $(npm --version) cannot configure trusted publishing (needs 11.15+ with a" >&2
+  echo "working --allow-publish, i.e. npm 12 or later)." >&2
+  echo "Upgrade with: npm install -g npm@latest" >&2
+  exit 1
+fi
+
 echo "Bootstrapping platform packages for $REPO (workflow: $WORKFLOW)"
 echo "npm user: $(npm whoami)"
 echo
@@ -45,7 +57,9 @@ for dir in npm/*/; do
     # Publish from a copy so the working tree keeps the real version.
     staging=$(mktemp -d)
     cp "${dir}package.json" "$staging/"
-    [[ -f "${dir}README.md" ]] && cp "${dir}README.md" "$staging/"
+    if [[ -f "${dir}README.md" ]]; then
+      cp "${dir}README.md" "$staging/"
+    fi
     (cd "$staging" && npm pkg set version="$PLACEHOLDER_VERSION" >/dev/null)
     npm publish "$staging" --access public $DRY_RUN
     rm -rf "$staging"


### PR DESCRIPTION
Hit while running the bootstrap from #193 for real.

`npm trust github --help` on npm 11.17.0 prints a usage line containing `--allow-publish`, but `lib/commands/trust/github.js` in that version never adds the flag to its `definitions` array — only npm 12 does (`trustDefinitions['allow-publish']`). So the parser rejects the flag its own help just advertised:

```
npm error Unknown flag: --allow-publish
```

Dropping the flag is not a fix: per npm's trusted-publishers docs, configurations created after 20 May 2026 must explicitly name at least one allowed action, so an unflagged call would just move the failure server-side. The script now checks `npm --version` before publishing anything, so the run fails immediately with an actionable message instead of dying half-way through the loop with one package already claimed.

Also fixes a latent `set -e` bug: `[[ -f "${dir}README.md" ]] && cp ...` is the entire command, so a missing README would exit the script rather than skip the copy. `napi create-npm-dirs` always writes one, so it never fired — but it would have been baffling if it had.

Verified by stubbing `npm --version` at 11.17.0 (guard fires, exit 1), confirming `--dry-run` still works without the guard, and re-running the real dry-run — which correctly reports `@wreq-js/binding-darwin-arm64` as already on the registry from the partial run and would claim the remaining six.