### PR TITLE
feat(sessions): add setCookies() to restore an exported cookie jar

### DIFF
--- a/docs/api-reference/sessions.mdx
+++ b/docs/api-reference/sessions.mdx
@@ -149,6 +149,42 @@ session.setCookie('token', 'abc123', 'https://example.com');
   URL that determines the cookie's domain and path scope.
 </ParamField>
 
+#### session.setCookies(cookies, url?)
+
+Restore a batch of cookies into the session jar, keeping every attribute. Accepts the output of
+[`getAllCookies()`](#session-getallcookies) directly, so a jar can round-trip through JSON.
+
+```typescript
+// Export
+fs.writeFileSync('cookies.json', JSON.stringify(session.getAllCookies()));
+
+// Import, in another process
+const restored = await createSession({ browser: 'chrome' });
+restored.setCookies(JSON.parse(fs.readFileSync('cookies.json', 'utf8')), 'https://example.com');
+```
+
+<ParamField path="cookies" type="SessionCookieInit[]" required>
+  Cookies to store. Only `name` and `value` are required; `domain`, `path`, `secure`, `httpOnly`,
+  `sameSite`, and `expiresAtMs` are applied when present.
+</ParamField>
+
+<ParamField path="url" type="string | URL">
+  Origin used to scope host-only cookies — those without a `domain`. Required whenever the batch
+  contains one, unless the cookie carries its own `url`.
+</ParamField>
+
+<Note>
+  A cookie with a `domain` describes its own scope. A cookie without one is host-only, and the jar
+  keeps that host as an internal key it never returns, so it is missing from the export. `url`
+  supplies it — which means a jar holding host-only cookies from **several** hosts cannot be
+  restored from a single `url`: they would all land on that one host. Set `url` on the individual
+  cookie to place each one precisely.
+</Note>
+
+The batch is validated before anything is stored, so a rejected cookie leaves the jar untouched
+instead of applying half the restore. Cookies whose `expiresAtMs` is already in the past are
+dropped rather than stored, matching how the jar treats an expired `Set-Cookie`.
+
 #### session.clearCookies()
 
 Clear all cookies from the session cookie jar.

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -130,6 +130,29 @@ session.setCookie('auth_token', 'my-token', 'https://example.com');
 const resp = await session.fetch('https://example.com/api');
 ```
 
+### Saving and restoring a jar
+
+Use `setCookies(cookies, url)` to put an exported jar back, attributes and all — the way to persist
+a logged-in session between runs:
+
+```typescript
+const saved = JSON.stringify(session.getAllCookies());
+
+const restored = await createSession({ browser: 'chrome' });
+restored.setCookies(JSON.parse(saved), 'https://example.com');
+```
+
+The `url` scopes cookies that have no `domain` of their own. Those are host-only cookies, and the
+jar keeps their host internally rather than returning it, so the export cannot carry it. If the jar
+holds host-only cookies from more than one host, give each cookie its own `url` instead:
+
+```typescript
+restored.setCookies([
+  { name: 'session_id', value: 'abc123', url: 'https://example.com' },
+  { name: 'consent', value: 'yes', url: 'https://cdn.other.test' },
+]);
+```
+
 ### Clearing cookies
 
 Use `clearCookies()` to remove all cookies from the session:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "anyhow",
  "btls",
  "bytes",
+ "cookie",
  "dashmap",
  "futures-util",
  "moka",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,9 @@ futures-util = "0.3.34"
 # Byte buffers for streaming bodies
 bytes = "1.12.1"
 
+# Cookie construction for Session.setCookies (must track wreq's cookie dependency)
+cookie = "0.18.1"
+
 # Neon for Node.js bindings
 neon = { version = "1.1.1", default-features = false, features = ["napi-6"] }
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1252,17 +1252,20 @@ pub fn get_all_session_cookies(session_id: &str) -> Result<Vec<SessionCookieInfo
 
     Ok(jar
         .get_all()
+        // wreq's wrapper only answers "is it Lax?" and "is it Strict?", which cannot tell
+        // `SameSite=None` apart from an absent attribute. The raw cookie reports the attribute
+        // itself.
+        .map(cookie::Cookie::from)
         .map(|cookie| {
-            let same_site = if cookie.same_site_lax() {
-                Some("lax".to_owned())
-            } else if cookie.same_site_strict() {
-                Some("strict".to_owned())
-            } else {
-                None
-            };
+            let same_site = cookie.same_site().map(|same_site| match same_site {
+                cookie::SameSite::Lax => "lax".to_owned(),
+                cookie::SameSite::Strict => "strict".to_owned(),
+                cookie::SameSite::None => "none".to_owned(),
+            });
 
             let expires_at_ms = cookie
-                .expires()
+                .expires_datetime()
+                .map(std::time::SystemTime::from)
                 .and_then(|expires| expires.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|duration| duration.as_millis() as f64);
 
@@ -1271,8 +1274,8 @@ pub fn get_all_session_cookies(session_id: &str) -> Result<Vec<SessionCookieInfo
                 value: cookie.value().to_owned(),
                 domain: cookie.domain().map(ToOwned::to_owned),
                 path: cookie.path().map(ToOwned::to_owned),
-                secure: cookie.secure(),
-                http_only: cookie.http_only(),
+                secure: cookie.secure().unwrap_or(false),
+                http_only: cookie.http_only().unwrap_or(false),
                 same_site,
                 expires_at_ms,
             }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1430,7 +1430,11 @@ pub fn set_session_cookies(
                     name
                 ));
             }
-            let nanos = (expires_at_ms * 1_000_000.0) as i128;
+            // f64 cannot hold epoch nanoseconds exactly, so scale the whole and fractional
+            // milliseconds separately to keep the exported timestamp to the millisecond.
+            let whole_ms = expires_at_ms.trunc();
+            let nanos =
+                (whole_ms as i128) * 1_000_000 + ((expires_at_ms - whole_ms) * 1_000_000.0) as i128;
             let expires =
                 cookie::time::OffsetDateTime::from_unix_timestamp_nanos(nanos).map_err(|_| {
                     anyhow!("Cookie \"{}\" has an out-of-range expiresAtMs value", name)

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1313,6 +1313,141 @@ pub fn set_session_cookie(session_id: &str, name: &str, value: &str, url: &str) 
     Ok(())
 }
 
+/// Extract the cookie-scoping host from a URL.
+fn host_from_url(url: &str) -> Result<String> {
+    let uri: wreq::Uri = url
+        .parse()
+        .with_context(|| format!("Invalid URL: {}", url))?;
+    cookie_origin_uri(&uri)
+        .host()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("URL has no host: {}", url))
+}
+
+/// A cookie to restore into a session jar, mirroring `SessionCookieInfo`.
+#[derive(Debug, Clone)]
+pub struct SessionCookieInput {
+    pub name: String,
+    pub value: String,
+    pub domain: Option<String>,
+    pub path: Option<String>,
+    pub secure: bool,
+    pub http_only: bool,
+    pub same_site: Option<String>,
+    pub expires_at_ms: Option<f64>,
+    /// Origin for this cookie alone, overriding the batch URL. Only consulted for host-only
+    /// cookies (those without a `domain`).
+    pub url: Option<String>,
+}
+
+/// Restore a batch of cookies (as exported by `get_all_session_cookies`) into a session jar.
+///
+/// Cookies that carry a `domain` are self-describing and scope themselves. Host-only cookies have
+/// no `domain` attribute, and the jar keeps their origin host as an internal key it never hands
+/// back, so `default_url` has to say which host they belong to.
+///
+/// The whole batch is validated before anything is stored, so a rejected cookie leaves the jar
+/// untouched instead of applying a partial restore.
+pub fn set_session_cookies(
+    session_id: &str,
+    cookies: &[SessionCookieInput],
+    default_url: Option<&str>,
+) -> Result<()> {
+    let default_host = match default_url {
+        Some(url) => Some(host_from_url(url)?),
+        None => None,
+    };
+
+    let mut prepared = Vec::with_capacity(cookies.len());
+    for (index, input) in cookies.iter().enumerate() {
+        let name = input.name.trim();
+        if name.is_empty() {
+            return Err(anyhow!("Cookie at index {} has an empty name", index));
+        }
+
+        let domain = input
+            .domain
+            .as_deref()
+            .map(str::trim)
+            .filter(|d| !d.is_empty());
+        let host = match domain {
+            // A leading dot is legal in Set-Cookie but not in a URI authority.
+            Some(domain) => domain.trim_start_matches('.').to_owned(),
+            None => match input.url.as_deref() {
+                Some(url) => host_from_url(url)?,
+                None => default_host.clone().ok_or_else(|| {
+                    anyhow!(
+                        "Cookie \"{}\" has no domain. Host-only cookies lose their origin host \
+                         when exported, so pass a URL to scope them",
+                        name
+                    )
+                })?,
+            },
+        };
+
+        let path = input
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| path.starts_with('/'))
+            .unwrap_or("/");
+
+        // The jar drops a Secure cookie arriving from an insecure origin, and only a secure origin
+        // may overwrite a stored Secure cookie, so restore every cookie over https.
+        let uri: wreq::Uri = format!("https://{}{}", host, path)
+            .parse()
+            .with_context(|| format!("Cookie \"{}\" has an invalid domain or path", name))?;
+
+        let mut builder = cookie::Cookie::build((name.to_owned(), input.value.clone()))
+            .path(path.to_owned())
+            .secure(input.secure)
+            .http_only(input.http_only);
+
+        if let Some(domain) = domain {
+            builder = builder.domain(domain.to_owned());
+        }
+
+        if let Some(same_site) = input.same_site.as_deref() {
+            let same_site = match same_site.trim().to_ascii_lowercase().as_str() {
+                "lax" => cookie::SameSite::Lax,
+                "strict" => cookie::SameSite::Strict,
+                "none" => cookie::SameSite::None,
+                other => {
+                    return Err(anyhow!(
+                        "Cookie \"{}\" has an invalid sameSite value: {}",
+                        name,
+                        other
+                    ));
+                }
+            };
+            builder = builder.same_site(same_site);
+        }
+
+        if let Some(expires_at_ms) = input.expires_at_ms {
+            if !expires_at_ms.is_finite() {
+                return Err(anyhow!(
+                    "Cookie \"{}\" has a non-finite expiresAtMs value",
+                    name
+                ));
+            }
+            let nanos = (expires_at_ms * 1_000_000.0) as i128;
+            let expires =
+                cookie::time::OffsetDateTime::from_unix_timestamp_nanos(nanos).map_err(|_| {
+                    anyhow!("Cookie \"{}\" has an out-of-range expiresAtMs value", name)
+                })?;
+            builder = builder.expires(expires);
+        }
+
+        prepared.push((builder.build(), uri));
+    }
+
+    let jar = SESSION_MANAGER.jar_for(session_id)?;
+    for (cookie, uri) in prepared {
+        jar.add(cookie, uri);
+    }
+    Ok(())
+}
+
 /// Get the cookie jar for a session. Used by websocket to share cookies.
 pub(crate) fn get_session_cookie_jar(session_id: &str) -> Result<Arc<Jar>> {
     SESSION_MANAGER.jar_for(session_id)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,11 +5,12 @@ mod websocket;
 
 use anyhow::anyhow;
 use client::{
-    HTTP_RUNTIME, RedirectMode, RequestEvent, RequestOptions, Response, TrustStoreMode,
-    clear_managed_session, create_managed_session, create_managed_transport, drop_body_stream,
-    drop_managed_session, drop_managed_transport, generate_session_id, get_all_session_cookies,
-    get_session_cookies, make_request, read_body_all as native_read_body_all,
-    read_body_chunk as native_read_body_chunk, set_session_cookie,
+    HTTP_RUNTIME, RedirectMode, RequestEvent, RequestOptions, Response, SessionCookieInput,
+    TrustStoreMode, clear_managed_session, create_managed_session, create_managed_transport,
+    drop_body_stream, drop_managed_session, drop_managed_transport, generate_session_id,
+    get_all_session_cookies, get_session_cookies, make_request,
+    read_body_all as native_read_body_all, read_body_chunk as native_read_body_chunk,
+    set_session_cookie, set_session_cookies,
 };
 use dashmap::DashMap;
 use futures_util::StreamExt;
@@ -1704,6 +1705,72 @@ fn set_cookie(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     Ok(cx.undefined())
 }
 
+fn set_cookies(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let session_id = cx.argument::<JsString>(0)?.value(&mut cx);
+    let entries = cx.argument::<JsArray>(1)?.to_vec(&mut cx)?;
+    let default_url = cx
+        .argument_opt(2)
+        .and_then(|v| v.downcast::<JsString, _>(&mut cx).ok())
+        .map(|v| v.value(&mut cx));
+
+    let mut cookies = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let obj = entry.downcast_or_throw::<JsObject, _>(&mut cx)?;
+
+        let name = obj.get::<JsString, _, _>(&mut cx, "name")?.value(&mut cx);
+        let value = obj.get::<JsString, _, _>(&mut cx, "value")?.value(&mut cx);
+        let domain = obj
+            .get_opt(&mut cx, "domain")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx));
+        let path = obj
+            .get_opt(&mut cx, "path")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx));
+        let secure = obj
+            .get_opt(&mut cx, "secure")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx))
+            .unwrap_or(false);
+        let http_only = obj
+            .get_opt(&mut cx, "httpOnly")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx))
+            .unwrap_or(false);
+        let same_site = obj
+            .get_opt(&mut cx, "sameSite")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx));
+        let expires_at_ms = obj
+            .get_opt(&mut cx, "expiresAtMs")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx));
+        let url = obj
+            .get_opt(&mut cx, "url")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| v.value(&mut cx));
+
+        cookies.push(SessionCookieInput {
+            name,
+            value,
+            domain,
+            path,
+            secure,
+            http_only,
+            same_site,
+            expires_at_ms,
+            url,
+        });
+    }
+
+    if let Err(e) = set_session_cookies(&session_id, &cookies, default_url.as_deref()) {
+        let msg = format!("{:#}", e);
+        return cx.throw_error(msg);
+    }
+
+    Ok(cx.undefined())
+}
+
 // Module initialization
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
@@ -1721,6 +1788,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("getCookies", get_cookies)?;
     cx.export_function("getAllCookies", get_all_cookies)?;
     cx.export_function("setCookie", set_cookie)?;
+    cx.export_function("setCookies", set_cookies)?;
     cx.export_function("createTransport", create_transport)?;
     cx.export_function("dropTransport", drop_transport)?;
     cx.export_function("websocketConnect", websocket_connect)?;

--- a/src/test/http/sessions.spec.ts
+++ b/src/test/http/sessions.spec.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
-import type { Session } from "../../wreq-js.js";
+import type { Session, SessionCookie } from "../../wreq-js.js";
 import { createSession, RequestError, withSession, fetch as wreqFetch } from "../../wreq-js.js";
 import { httpUrl } from "../helpers/http.js";
 
@@ -88,6 +88,13 @@ describe("HTTP sessions", () => {
       },
       (error: unknown) => error instanceof RequestError && /Session has been closed/.test(error.message),
     );
+
+    assert.throws(
+      () => {
+        session.setCookies([{ name: "k", value: "v", url: httpUrl("/cookies") }]);
+      },
+      (error: unknown) => error instanceof RequestError && /Session has been closed/.test(error.message),
+    );
   });
 
   test("getAllCookies returns cookies without needing a URL", async () => {
@@ -141,6 +148,105 @@ describe("HTTP sessions", () => {
           { name: "token", value: "root", secure: false, httpOnly: false },
         ],
       );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("setCookies restores an exported jar with every attribute", async () => {
+    const source = await createSession({ browser: "chrome_142" });
+    const target = await createSession({ browser: "chrome_142" });
+
+    try {
+      source.setCookie("token", "abc123", httpUrl("/"));
+      source.setCookie("scoped", "nested", httpUrl("/account/settings"));
+      source.setCookie(
+        "flagged",
+        "on; Domain=127.0.0.1; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=3600",
+        "https://127.0.0.1/",
+      );
+
+      const exported = source.getAllCookies();
+      assert.strictEqual(exported.length, 3);
+
+      // Cross a JSON round-trip the way a caller persisting a jar to disk would.
+      target.setCookies(JSON.parse(JSON.stringify(exported)), httpUrl("/"));
+
+      const byName = (cookies: SessionCookie[]) => [...cookies].sort((a, b) => a.name.localeCompare(b.name));
+      assert.deepStrictEqual(byName(target.getAllCookies()), byName(exported));
+
+      const response = await target.fetch(httpUrl("/cookies"), { timeout: 10_000 });
+      const body = await response.json<{ cookies: Record<string, string> }>();
+      assert.strictEqual(body.cookies.token, "abc123");
+    } finally {
+      await source.close();
+      await target.close();
+    }
+  });
+
+  test("setCookies scopes host-only cookies per cookie url", async () => {
+    const session = await createSession({ browser: "chrome_142" });
+
+    try {
+      session.setCookies([
+        { name: "here", value: "local", url: httpUrl("/") },
+        { name: "elsewhere", value: "remote", url: "https://example.com/" },
+      ]);
+
+      assert.deepStrictEqual(session.getCookies(httpUrl("/")), { here: "local" });
+      assert.deepStrictEqual(session.getCookies("https://example.com/"), { elsewhere: "remote" });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("setCookies rejects a bad batch without touching the jar", async () => {
+    const session = await createSession({ browser: "chrome_142" });
+
+    try {
+      session.setCookie("keep", "me", httpUrl("/"));
+
+      assert.throws(
+        () => {
+          session.setCookies([{ name: "stray", value: "1" }]);
+        },
+        (error: unknown) => error instanceof RequestError && /has no domain/.test(error.message),
+        "Host-only cookies need a URL to scope them",
+      );
+
+      assert.throws(
+        () => {
+          session.setCookies([
+            { name: "good", value: "1", domain: "127.0.0.1" },
+            { name: "bad", value: "1", domain: "127.0.0.1", sameSite: "sometimes" as never },
+          ]);
+        },
+        (error: unknown) => error instanceof RequestError && /invalid sameSite/.test(error.message),
+      );
+
+      assert.deepStrictEqual(
+        session.getCookies(httpUrl("/")),
+        { keep: "me" },
+        "A rejected batch should leave the jar untouched",
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("setCookies drops cookies that have already expired", async () => {
+    const session = await createSession({ browser: "chrome_142" });
+
+    try {
+      session.setCookies(
+        [
+          { name: "fresh", value: "1", expiresAtMs: Date.now() + 3_600_000 },
+          { name: "stale", value: "1", expiresAtMs: Date.now() - 60_000 },
+        ],
+        httpUrl("/"),
+      );
+
+      assert.deepStrictEqual(session.getCookies(httpUrl("/")), { fresh: "1" });
     } finally {
       await session.close();
     }

--- a/src/test/http/sessions.spec.ts
+++ b/src/test/http/sessions.spec.ts
@@ -153,6 +153,34 @@ describe("HTTP sessions", () => {
     }
   });
 
+  test("getAllCookies reports every SameSite value", async () => {
+    const session = await createSession({ browser: "chrome_142" });
+
+    try {
+      session.setCookies(
+        [
+          { name: "lax", value: "1", sameSite: "lax" },
+          { name: "strict", value: "1", sameSite: "strict" },
+          // SameSite=None is the case wreq's cookie wrapper cannot tell from an absent attribute.
+          { name: "none", value: "1", sameSite: "none", secure: true },
+          { name: "unset", value: "1" },
+        ],
+        httpUrl("/"),
+      );
+
+      const bySameSite = Object.fromEntries(session.getAllCookies().map((cookie) => [cookie.name, cookie.sameSite]));
+
+      assert.deepStrictEqual(bySameSite, {
+        lax: "lax",
+        strict: "strict",
+        none: "none",
+        unset: undefined,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
   test("setCookies restores an exported jar with every attribute", async () => {
     const source = await createSession({ browser: "chrome_142" });
     const target = await createSession({ browser: "chrome_142" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,36 @@ export interface SessionCookie {
 }
 
 /**
+ * A cookie accepted by {@link Session.setCookies}. Every {@link SessionCookie}
+ * returned by {@link Session.getAllCookies} is a valid input, so an exported jar
+ * can be handed straight back.
+ */
+export interface SessionCookieInit {
+  name: string;
+  value: string;
+  /**
+   * Domain the cookie is scoped to, with or without a leading dot. When omitted the
+   * cookie is host-only and {@link Session.setCookies} needs a URL to scope it.
+   */
+  domain?: string;
+  /** @default "/" */
+  path?: string;
+  /** @default false */
+  secure?: boolean;
+  /** @default false */
+  httpOnly?: boolean;
+  sameSite?: "lax" | "strict" | "none";
+  /** Absolute expiry in milliseconds since the epoch. Omit for a session cookie. */
+  expiresAtMs?: number;
+  /**
+   * Origin for this cookie alone, overriding the URL passed to {@link Session.setCookies}.
+   * Only consulted for host-only cookies (those without a `domain`), and the way to restore a
+   * jar holding host-only cookies from more than one host.
+   */
+  url?: string;
+}
+
+/**
  * A tuple of [name, value] pairs used for initializing headers.
  * Both name and value must be strings.
  *

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -32,6 +32,7 @@ import type {
   RequestEvent,
   RequestOptions,
   SessionCookie,
+  SessionCookieInit,
   SessionHandle,
   SessionWebSocketOptions,
   TlsVersion,
@@ -143,6 +144,7 @@ let nativeBinding: {
   getCookies: (sessionId: string, url: string) => Record<string, string>;
   getAllCookies: (sessionId: string) => SessionCookie[];
   setCookie: (sessionId: string, name: string, value: string, url: string) => void;
+  setCookies: (sessionId: string, cookies: SessionCookieInit[], url?: string) => void;
   createTransport: (options: NativeTransportOptions) => string;
   dropTransport: (transportId: string) => void;
   getOperatingSystems?: () => string[];
@@ -1196,6 +1198,48 @@ export class Session implements SessionHandle {
     this.ensureActive();
     try {
       nativeBinding.setCookie(this.id, name, value, String(url));
+    } catch (error) {
+      throw new RequestError(String(error));
+    }
+  }
+
+  /**
+   * Restore a batch of cookies into the session jar, keeping every attribute.
+   *
+   * Accepts the output of {@link Session.getAllCookies} directly, which makes a cookie jar
+   * round-trip through JSON possible.
+   *
+   * Cookies that carry a `domain` scope themselves. A cookie without one is host-only, and the
+   * jar keeps its origin host internally rather than returning it, so `url` supplies the host
+   * those cookies belong to. Passing `url` is therefore required whenever the batch contains a
+   * host-only cookie.
+   *
+   * Because that host is missing from the export, a jar holding host-only cookies from several
+   * hosts cannot be restored from `url` alone — every one of them lands on the host `url` names.
+   * Set `url` on the individual cookie to place it precisely.
+   *
+   * The batch is validated before anything is stored: if one cookie is rejected the jar is left
+   * untouched. Cookies whose `expiresAtMs` is already in the past are dropped rather than stored,
+   * matching how the jar treats an expired `Set-Cookie`.
+   *
+   * @param cookies - Cookies to store
+   * @param url - Origin used to scope host-only cookies that do not carry their own `url`
+   *
+   * @example
+   * ```typescript
+   * const saved = JSON.stringify(session.getAllCookies());
+   * // ...later, in another process
+   * const restored = await createSession({ browser: 'chrome' });
+   * restored.setCookies(JSON.parse(saved), 'https://example.com');
+   * ```
+   */
+  setCookies(cookies: SessionCookieInit[], url?: string | URL): void {
+    this.ensureActive();
+    if (!Array.isArray(cookies)) {
+      throw new RequestError("setCookies expects an array of cookies");
+    }
+    try {
+      nativeBinding.setCookies(this.id, cookies, url === undefined ? undefined : String(url));
     } catch (error) {
       throw new RequestError(String(error));
     }
@@ -3951,6 +3995,8 @@ export type {
   RequestEventType,
   RequestInit,
   RequestOptions,
+  SessionCookie,
+  SessionCookieInit,
   SessionHandle,
   SessionWebSocketOptions,
   TlsVersion,


### PR DESCRIPTION
## Closes #201

### Problem

`getAllCookies()` returns cookies with full metadata, but there's no way to put them back. `setCookie(name, value, url)` only takes a name/value pair, so domain, path, secure, httpOnly, sameSite and expiry are all lost on re-import. That makes a jar export/import round-trip impossible, which is what you need to persist a logged-in session across process restarts.

### Changes

`session.setCookies(cookies, url?)` takes the output of `getAllCookies()` directly:

```typescript
const saved = JSON.stringify(session.getAllCookies());

const restored = await createSession({ browser: 'chrome' });
restored.setCookies(JSON.parse(saved), 'https://example.com');
```

Each cookie is built with `cookie::CookieBuilder` rather than by formatting a `Set-Cookie` string, so a value containing `;` stays verbatim instead of being reparsed as attributes. The whole batch is validated before anything is stored, so a rejected cookie leaves the jar untouched rather than applying half a restore. Cookies already past `expiresAtMs` are dropped, matching how the jar treats an expired `Set-Cookie`.

The `url` scopes host-only cookies, the ones with no `Domain` of their own. wreq's jar keeps their origin host as an internal key and doesn't return it from `get_all()`, so it's absent from the export and has to be supplied. A jar holding host-only cookies from several hosts therefore can't be restored from one `url`; `SessionCookieInit` also accepts a per-cookie `url` for that case. Upstream fix proposed in 0x676e67/wreq#1269, which would let the export carry the host and make both arguments unnecessary.

Two other fixes came out of this:

- `getAllCookies()` now reports `sameSite: "none"`. wreq's `Cookie` wrapper only exposes `same_site_lax()`/`same_site_strict()`, so `SameSite=None` was indistinguishable from an absent attribute and exported as `undefined`. Real servers use it: upwork.com sends it on `__cf_bm`, `__cflb` and `AWSALBTGCORS`. The export now reads the attribute off the raw cookie.
- `expiresAtMs` no longer drifts by a millisecond per round-trip. Epoch nanoseconds exceed f64's exact integer range, so `ms * 1e6` lost precision; whole and fractional milliseconds are now scaled separately.

### Tests

Five added to `src/test/http/sessions.spec.ts`: attribute-preserving restore through a JSON round-trip plus a live request, per-cookie scoping across two hosts, rejected-batch atomicity, expired-cookie drop, every `SameSite` value, and `setCookies` on a disposed session. 199 pass.

Checked against tough-cookie 6.0.2 as an oracle: 15 `Set-Cookie` shapes compared field by field, including `SameSite=None`, lowercase `samesite=none`, uppercase `SAMESITE=STRICT` and an invalid `SameSite=Bogus`, plus cookie selection across 6 URLs covering Secure filtering, path matching, domain matching and host-only scoping. All agree.

Also verified against real sites: a 17-cookie jar spanning httpbingo.org, google.com, github.com and upwork.com round-trips byte-identical, restored `__cf_bm` is accepted by Cloudflare (200 on patreon.com, openai.com, upwork.com), and a jar written to disk in one process restores in another with the origin server seeing identical cookies.

### Docs

`docs/api-reference/sessions.mdx` and `docs/concepts/sessions.mdx`.
