### PR TITLE
perf: cache TLS stores, pool clients, and optimize response bodies

### DIFF
--- a/docs/api-reference/sessions.mdx
+++ b/docs/api-reference/sessions.mdx
@@ -201,6 +201,12 @@ Close the session and release resources. Always call this when done.
 await session.close();
 ```
 
+A session's cookie jar lives in the native addon until the session is closed. It never
+expires on its own, so a session that sits idle for hours still sends its cookies on the
+next request. If a `Session` object is garbage collected without `close()` having been
+called, its native state is released by a finalizer, but relying on that delays cleanup
+until the runtime decides to collect; prefer `close()` or `await using`.
+
 ### Example
 
 ```typescript

--- a/docs/api-reference/transport.mdx
+++ b/docs/api-reference/transport.mdx
@@ -134,6 +134,11 @@ await transport.close();
 
 After closing, `transport.closed` becomes `true` and the transport can no longer be used.
 
+A transport's native client and connection pool live until it is closed. If a `Transport`
+object is garbage collected without `close()` having been called, a finalizer releases the
+native client and its pooled connections, but that only happens whenever the runtime decides
+to collect; prefer `close()` or `await using` for prompt cleanup.
+
 ## Sharing a transport across cookie jars
 
 If you need separate cookie jars with shared transport settings (for example, multiple sessions through the same proxy), you can pass the same transport to multiple `Session.fetch()` calls.

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -15,6 +15,14 @@ For multi-step flows (like login sequences), use **sessions** to persist state.
 | Multi-step login or reuse cookies | Session | Shared session context |
 | Parallel jobs that must stay isolated | Ephemeral or per-job session | Avoid cross-talk between tasks |
 
+### What request isolation covers
+
+By default, ephemeral calls use separate cookie jars and network connections. They do not resume TLS sessions from earlier calls. Parsed trust roots and transport configuration can be cached without sharing cookies, live connections, or TLS tickets.
+
+Passing a shared `transport` opts into connection and TLS reuse, even when you call `fetch()` without a Session. It keeps cookie jars separate, but the server can link requests through the reused connection.
+
+Request isolation does not hide your IP address or remove identifiers you send in URLs, headers, or request bodies.
+
 ## Creating a session
 
 ```typescript

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1999,6 +1999,7 @@ dependencies = [
  "cookie",
  "dashmap",
  "futures-util",
+ "libloading",
  "moka",
  "neon",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0.151"
 anyhow = "1.0.104"
 
 # Async runtime
-tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "macros", "time"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "macros"] }
 tokio-util = "0.7.19"
 
 # Global state management

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,10 @@ bytes = "1.12.1"
 cookie = "0.18.2"
 
 # Neon for Node.js bindings
-neon = { version = "1.1.1", default-features = false, features = ["napi-6"] }
+neon = { version = "1.1.1", default-features = false, features = ["napi-6", "sys"] }
+
+# Resolves napi_create_external_buffer from the host for zero-copy bodies (see external_buffer.rs)
+libloading = "0.8"
 
 # Concurrent maps
 dashmap = "6.2.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0.151"
 anyhow = "1.0.104"
 
 # Async runtime
-tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 tokio-util = "0.7.19"
 
 # Global state management

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use tokio::sync::{Mutex, Semaphore, mpsc};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 use wreq::cookie::Jar;
 use wreq::header::OrigHeaderMap;
@@ -402,18 +403,32 @@ const STREAM_BUFFER_BYTES: usize = 256 * 1024;
 // Upper bound on how many buffered frames one readBodyChunk() call merges.
 const STREAM_CHUNK_BUDGET: usize = 256 * 1024;
 
+// When a body is abandoned with data still unread, the pump keeps reading and discards
+// up to this much so the connection can go back to the pool; past it the body is dropped
+// and hyper closes the connection. undici's dump() draws the same line at 128 KiB; this
+// matches the read-ahead buffer so "fits in the buffer" and "worth draining" agree.
+const ABANDON_DRAIN_LIMIT: u64 = STREAM_BUFFER_BYTES as u64;
+
 struct BodyStreamState {
     frames: mpsc::UnboundedReceiver<wreq::Result<Bytes>>,
     /// Bytes the pump may still buffer. The pump takes permits per frame, the reader
-    /// returns them; dropping the state closes it and stops the pump.
+    /// returns them.
     capacity: Arc<Semaphore>,
     /// An error taken off the buffer while coalescing, returned by the next read.
     pending_error: Option<wreq::Error>,
 }
 
-impl Drop for BodyStreamState {
+struct StoredBody {
+    state: Mutex<BodyStreamState>,
+    /// Fired when nothing will read the body any more: cancelBody() from JS, or the
+    /// entry being evicted. Explicit rather than relying on the value being dropped,
+    /// because the cache releases evicted values from its housekeeper, not inline.
+    abandon: CancellationToken,
+}
+
+impl Drop for StoredBody {
     fn drop(&mut self) {
-        self.capacity.close();
+        self.abandon.cancel();
     }
 }
 
@@ -421,7 +436,7 @@ fn buffer_permits(len: usize) -> u32 {
     len.min(STREAM_BUFFER_BYTES) as u32
 }
 
-static BODY_STREAMS: LazyLock<Cache<u64, Arc<Mutex<BodyStreamState>>>> = LazyLock::new(|| {
+static BODY_STREAMS: LazyLock<Cache<u64, Arc<StoredBody>>> = LazyLock::new(|| {
     Cache::builder()
         .time_to_idle(Duration::from_secs(300))
         .build()
@@ -507,17 +522,52 @@ fn build_cert_store_uncached(mode: TrustStoreMode) -> Result<CertStore> {
     }
 }
 
-pub fn store_body_stream(mut stream: ResponseBodyStream) -> u64 {
+fn abandoned_body_is_drainable(content_length: Option<u64>, delivered: u64) -> bool {
+    match content_length {
+        Some(total) => total.saturating_sub(delivered) <= ABANDON_DRAIN_LIMIT,
+        None => true,
+    }
+}
+
+pub fn store_body_stream(mut stream: ResponseBodyStream, content_length: Option<u64>) -> u64 {
     let handle = next_body_handle();
     let (tx, rx) = mpsc::unbounded_channel();
     let capacity = Arc::new(Semaphore::new(STREAM_BUFFER_BYTES));
+    let abandon = CancellationToken::new();
 
     let pump_capacity = capacity.clone();
+    let pump_abandon = abandon.clone();
     HTTP_RUNTIME.spawn(async move {
+        let mut delivered: u64 = 0;
+        let mut drained: u64 = 0;
+        let mut draining = false;
+
         loop {
+            if draining {
+                // Nobody will read this body. Discard the remainder up to the cap so
+                // the connection can be reused; past it, drop the stream and let hyper
+                // close the connection.
+                match stream.next().await {
+                    Some(Ok(bytes)) => {
+                        drained += bytes.len() as u64;
+                        if drained > ABANDON_DRAIN_LIMIT {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+                continue;
+            }
+
             let item = tokio::select! {
-                // The reader side is gone (handle dropped, cancelled, or evicted).
-                _ = tx.closed() => break,
+                // The reader side is gone (cancelled from JS, or the entry was evicted).
+                _ = pump_abandon.cancelled() => {
+                    if abandoned_body_is_drainable(content_length, delivered) {
+                        draining = true;
+                        continue;
+                    }
+                    break;
+                }
                 item = stream.next() => match item {
                     Some(item) => item,
                     None => break,
@@ -526,10 +576,23 @@ pub fn store_body_stream(mut stream: ResponseBodyStream) -> u64 {
 
             let is_err = item.is_err();
             if let Ok(bytes) = &item {
-                match pump_capacity.acquire_many(buffer_permits(bytes.len())).await {
-                    Ok(permits) => permits.forget(),
-                    Err(_) => break,
+                let permits = tokio::select! {
+                    _ = pump_abandon.cancelled() => None,
+                    permits = pump_capacity.acquire_many(buffer_permits(bytes.len())) => permits.ok(),
+                };
+                match permits {
+                    Some(permits) => permits.forget(),
+                    None => {
+                        // Abandoned while waiting for buffer room; this frame counts as drained.
+                        if abandoned_body_is_drainable(content_length, delivered) {
+                            drained += bytes.len() as u64;
+                            draining = true;
+                            continue;
+                        }
+                        break;
+                    }
                 }
+                delivered += bytes.len() as u64;
             }
             if tx.send(item).is_err() || is_err {
                 break;
@@ -539,11 +602,14 @@ pub fn store_body_stream(mut stream: ResponseBodyStream) -> u64 {
 
     BODY_STREAMS.insert(
         handle,
-        Arc::new(Mutex::new(BodyStreamState {
-            frames: rx,
-            capacity,
-            pending_error: None,
-        })),
+        Arc::new(StoredBody {
+            state: Mutex::new(BodyStreamState {
+                frames: rx,
+                capacity,
+                pending_error: None,
+            }),
+            abandon,
+        }),
     );
     handle
 }
@@ -571,7 +637,7 @@ pub async fn read_body_chunk(handle: u64) -> Result<Option<Bytes>> {
         .get(&handle)
         .ok_or_else(|| anyhow!("Body handle {} not found", handle))?;
 
-    let mut guard = stream.lock().await;
+    let mut guard = stream.state.lock().await;
 
     if let Some(err) = guard.pending_error.take() {
         return Err(finish_body_stream_error(handle, err));
@@ -620,7 +686,7 @@ pub async fn read_body_all(handle: u64) -> Result<Bytes> {
         .remove(&handle)
         .ok_or_else(|| anyhow!("Body handle {} not found", handle))?;
 
-    let mut guard = stream.lock().await;
+    let mut guard = stream.state.lock().await;
     let mut chunks: Vec<Bytes> = Vec::new();
     let mut total_len = 0usize;
 
@@ -649,7 +715,9 @@ pub async fn read_body_all(handle: u64) -> Result<Bytes> {
 }
 
 pub fn drop_body_stream(handle: u64) {
-    BODY_STREAMS.invalidate(&handle);
+    if let Some(body) = BODY_STREAMS.remove(&handle) {
+        body.abandon.cancel();
+    }
     BODY_EVENT_STATES.remove(&handle);
 }
 
@@ -994,7 +1062,7 @@ async fn make_request_inner(
                     } else {
                         Box::pin(stream::iter(prefix.into_iter().map(Ok)).chain(stream))
                     };
-                    let handle = store_body_stream(stream);
+                    let handle = store_body_stream(stream, content_length);
                     if let Some(sink) = event_sink.as_ref() {
                         BODY_EVENT_STATES.insert(
                             handle,

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -507,9 +507,16 @@ fn build_cert_store(mode: TrustStoreMode) -> Result<CertStore> {
         return Ok(store.clone());
     }
 
-    let store = build_cert_store_uncached(mode)?;
-    CERT_STORES.insert(mode, store.clone());
-    Ok(store)
+    // Concurrent cold requests must not all parse the same trust roots. Only
+    // immutable trust configuration is shared; connection state stays separate.
+    match CERT_STORES.entry(mode) {
+        dashmap::mapref::entry::Entry::Occupied(entry) => Ok(entry.get().clone()),
+        dashmap::mapref::entry::Entry::Vacant(entry) => {
+            let store = build_cert_store_uncached(mode)?;
+            entry.insert(store.clone());
+            Ok(store)
+        }
+    }
 }
 
 fn build_cert_store_uncached(mode: TrustStoreMode) -> Result<CertStore> {
@@ -852,9 +859,13 @@ impl EphemeralClientManager {
             return Ok(resolved);
         }
 
-        let resolved = Arc::new(build_ephemeral_client(&config)?);
-        self.cache.insert(config, resolved.clone());
-        Ok(resolved)
+        // Coalesce cold builds for the same configuration, while retaining the
+        // no-pooling and no-TLS-resumption policy of build_ephemeral_client.
+        self.cache
+            .try_get_with(config.clone(), || {
+                build_ephemeral_client(&config).map(Arc::new)
+            })
+            .map_err(|error| anyhow!("{error:#}"))
     }
 }
 
@@ -1392,6 +1403,48 @@ mod tests {
             capture_diagnostics: false,
             event_sink: None,
         }
+    }
+
+    #[test]
+    fn concurrent_ephemeral_clients_share_only_the_matching_configuration() {
+        let manager = EphemeralClientManager::new();
+        let mut options = base_request_options();
+        options.insecure = true;
+        let config = SessionConfig::from_request(&options);
+        let barrier = std::sync::Barrier::new(16);
+
+        let clients = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|_| {
+                    let config = config.clone();
+                    let manager = &manager;
+                    let barrier = &barrier;
+                    scope.spawn(move || {
+                        barrier.wait();
+                        manager.client_for(config).expect("build ephemeral client")
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+
+        for client in &clients[1..] {
+            assert!(
+                Arc::ptr_eq(&clients[0], client),
+                "cold callers must share one client build"
+            );
+        }
+        options.browser_os = Some(BrowserEmulationOS::Windows);
+        let other = manager
+            .client_for(SessionConfig::from_request(&options))
+            .unwrap();
+        assert!(
+            !Arc::ptr_eq(&clients[0], &other),
+            "different configurations must stay separate"
+        );
     }
 
     #[test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 use wreq::cookie::Jar;
 use wreq::header::OrigHeaderMap;
 use wreq::tls::TlsInfo;
+use wreq::tls::session::{Key, TlsSession, TlsSessionCache};
 use wreq::tls::trust::CertStore;
 use wreq::{Client as HttpClient, Method, Proxy, redirect};
 
@@ -484,6 +485,22 @@ fn next_body_handle() -> u64 {
 // system store into a BoringSSL X509_STORE, which costs milliseconds of CPU; the
 // result is immutable and cheap to clone (Arc), so it is built once per process.
 static CERT_STORES: LazyLock<DashMap<TrustStoreMode, CertStore>> = LazyLock::new(DashMap::new);
+
+// Isolated `fetch()` calls share one cached ephemeral client for speed, but a client's
+// TLS session cache would then carry session tickets from one call to the next, and the
+// server sees the second connection resume the first, linking two requests that are meant
+// to be independent. This cache stores nothing and returns nothing, so those connections
+// never resume. It leaves `pre_shared_key` (and therefore the ClientHello) untouched: a
+// browser opening its first connection has no session to resume either. Sessions and
+// explicit transports keep wreq's real LRU cache, where resumption is wanted.
+struct NoResumptionSessionCache;
+
+impl TlsSessionCache for NoResumptionSessionCache {
+    fn put(&self, _key: Key, _session: TlsSession) {}
+    fn pop(&self, _key: &Key) -> Option<TlsSession> {
+        None
+    }
+}
 
 fn build_cert_store(mode: TrustStoreMode) -> Result<CertStore> {
     if let Some(store) = CERT_STORES.get(&mode) {
@@ -1177,7 +1194,9 @@ fn build_ephemeral_client(config: &SessionConfig) -> Result<ResolvedClient> {
 
     let mut client_builder = HttpClient::builder()
         .emulation(emulation)
-        .pool_max_idle_per_host(0);
+        .pool_max_idle_per_host(0)
+        // Isolated fetches must not resume each other's TLS sessions (see the cache above).
+        .tls_session_cache(NoResumptionSessionCache);
 
     if let Some(proxy_url) = config.proxy.as_deref() {
         let proxy = Proxy::all(proxy_url).context("Failed to create proxy")?;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -345,7 +345,22 @@ fn next_body_handle() -> u64 {
     NEXT_BODY_HANDLE.fetch_add(1, Ordering::Relaxed)
 }
 
+// Built trust stores, one per mode. Building one parses ~150 Mozilla roots plus the
+// system store into a BoringSSL X509_STORE, which costs milliseconds of CPU; the
+// result is immutable and cheap to clone (Arc), so it is built once per process.
+static CERT_STORES: LazyLock<DashMap<TrustStoreMode, CertStore>> = LazyLock::new(DashMap::new);
+
 fn build_cert_store(mode: TrustStoreMode) -> Result<CertStore> {
+    if let Some(store) = CERT_STORES.get(&mode) {
+        return Ok(store.clone());
+    }
+
+    let store = build_cert_store_uncached(mode)?;
+    CERT_STORES.insert(mode, store.clone());
+    Ok(store)
+}
+
+fn build_cert_store_uncached(mode: TrustStoreMode) -> Result<CertStore> {
     match mode {
         TrustStoreMode::Mozilla => CertStore::builder()
             .add_der_certs(webpki_root_certs::TLS_SERVER_ROOT_CERTS)

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore, mpsc};
 use uuid::Uuid;
 use wreq::cookie::Jar;
 use wreq::header::OrigHeaderMap;
@@ -392,7 +392,36 @@ struct BodyEventState {
     url: String,
 }
 
-static BODY_STREAMS: LazyLock<Cache<u64, Arc<Mutex<ResponseBodyStream>>>> = LazyLock::new(|| {
+// A streamed body is pulled off the connection by a pump task into a bounded buffer,
+// the way Node's Readable keeps reading up to its highWaterMark and Bun's fetch fills
+// its native response buffer between JS reads. hyper's body channel holds a single
+// frame and only reads more once it is polled, so without the pump each
+// readBodyChunk() call could return at most one frame, one FFI round trip per frame.
+const STREAM_BUFFER_BYTES: usize = 256 * 1024;
+
+// Upper bound on how many buffered frames one readBodyChunk() call merges.
+const STREAM_CHUNK_BUDGET: usize = 256 * 1024;
+
+struct BodyStreamState {
+    frames: mpsc::UnboundedReceiver<wreq::Result<Bytes>>,
+    /// Bytes the pump may still buffer. The pump takes permits per frame, the reader
+    /// returns them; dropping the state closes it and stops the pump.
+    capacity: Arc<Semaphore>,
+    /// An error taken off the buffer while coalescing, returned by the next read.
+    pending_error: Option<wreq::Error>,
+}
+
+impl Drop for BodyStreamState {
+    fn drop(&mut self) {
+        self.capacity.close();
+    }
+}
+
+fn buffer_permits(len: usize) -> u32 {
+    len.min(STREAM_BUFFER_BYTES) as u32
+}
+
+static BODY_STREAMS: LazyLock<Cache<u64, Arc<Mutex<BodyStreamState>>>> = LazyLock::new(|| {
     Cache::builder()
         .time_to_idle(Duration::from_secs(300))
         .build()
@@ -478,10 +507,63 @@ fn build_cert_store_uncached(mode: TrustStoreMode) -> Result<CertStore> {
     }
 }
 
-pub fn store_body_stream(stream: ResponseBodyStream) -> u64 {
+pub fn store_body_stream(mut stream: ResponseBodyStream) -> u64 {
     let handle = next_body_handle();
-    BODY_STREAMS.insert(handle, Arc::new(Mutex::new(stream)));
+    let (tx, rx) = mpsc::unbounded_channel();
+    let capacity = Arc::new(Semaphore::new(STREAM_BUFFER_BYTES));
+
+    let pump_capacity = capacity.clone();
+    HTTP_RUNTIME.spawn(async move {
+        loop {
+            let item = tokio::select! {
+                // The reader side is gone (handle dropped, cancelled, or evicted).
+                _ = tx.closed() => break,
+                item = stream.next() => match item {
+                    Some(item) => item,
+                    None => break,
+                },
+            };
+
+            let is_err = item.is_err();
+            if let Ok(bytes) = &item {
+                match pump_capacity.acquire_many(buffer_permits(bytes.len())).await {
+                    Ok(permits) => permits.forget(),
+                    Err(_) => break,
+                }
+            }
+            if tx.send(item).is_err() || is_err {
+                break;
+            }
+        }
+    });
+
+    BODY_STREAMS.insert(
+        handle,
+        Arc::new(Mutex::new(BodyStreamState {
+            frames: rx,
+            capacity,
+            pending_error: None,
+        })),
+    );
     handle
+}
+
+fn finish_body_stream_error(handle: u64, err: wreq::Error) -> anyhow::Error {
+    BODY_STREAMS.invalidate(&handle);
+    if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
+        (state.sink)(RequestEvent::Error {
+            timestamp_ms: 0,
+            message: format!("{:#}", err),
+        });
+    }
+    err.into()
+}
+
+fn finish_body_stream_end(handle: u64) {
+    BODY_STREAMS.invalidate(&handle);
+    if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
+        emit_body_complete(&state);
+    }
 }
 
 pub async fn read_body_chunk(handle: u64) -> Result<Option<Bytes>> {
@@ -490,33 +572,46 @@ pub async fn read_body_chunk(handle: u64) -> Result<Option<Bytes>> {
         .ok_or_else(|| anyhow!("Body handle {} not found", handle))?;
 
     let mut guard = stream.lock().await;
-    let next = guard.next().await;
 
-    match next {
-        Some(Ok(bytes)) => {
-            if let Some(state) = BODY_EVENT_STATES.get(&handle) {
-                emit_body_progress(&state, bytes.len() as u64);
-            }
-            Ok(Some(bytes))
-        }
-        Some(Err(err)) => {
-            BODY_STREAMS.invalidate(&handle);
-            if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
-                (state.sink)(RequestEvent::Error {
-                    timestamp_ms: 0,
-                    message: format!("{:#}", err),
-                });
-            }
-            Err(err.into())
-        }
+    if let Some(err) = guard.pending_error.take() {
+        return Err(finish_body_stream_error(handle, err));
+    }
+
+    // Wait for one frame; this is the only point that blocks on the network.
+    let first = match guard.frames.recv().await {
+        Some(Ok(bytes)) => bytes,
+        Some(Err(err)) => return Err(finish_body_stream_error(handle, err)),
         None => {
-            BODY_STREAMS.invalidate(&handle);
-            if let Some((_, state)) = BODY_EVENT_STATES.remove(&handle) {
-                emit_body_complete(&state);
+            finish_body_stream_end(handle);
+            return Ok(None);
+        }
+    };
+    guard.capacity.add_permits(buffer_permits(first.len()) as usize);
+
+    // Then merge whatever the pump has already buffered, so a body that arrives in
+    // many small frames does not cost one FFI round trip per frame.
+    let mut total_len = first.len();
+    let mut chunks = vec![first];
+    while total_len < STREAM_CHUNK_BUDGET {
+        match guard.frames.try_recv() {
+            Ok(Ok(bytes)) => {
+                guard.capacity.add_permits(buffer_permits(bytes.len()) as usize);
+                total_len += bytes.len();
+                chunks.push(bytes);
             }
-            Ok(None)
+            Ok(Err(err)) => {
+                guard.pending_error = Some(err);
+                break;
+            }
+            Err(_) => break, // empty for now, or ended; the next read reports it
         }
     }
+
+    let bytes = concat_chunks(chunks, total_len);
+    if let Some(state) = BODY_EVENT_STATES.get(&handle) {
+        emit_body_progress(&state, bytes.len() as u64);
+    }
+    Ok(Some(bytes))
 }
 
 /// Read entire body into a single buffer. More efficient than streaming for small bodies.
@@ -529,8 +624,16 @@ pub async fn read_body_all(handle: u64) -> Result<Bytes> {
     let mut chunks: Vec<Bytes> = Vec::new();
     let mut total_len = 0usize;
 
-    while let Some(result) = guard.next().await {
-        let bytes = result?;
+    if let Some(err) = guard.pending_error.take() {
+        return Err(finish_body_stream_error(handle, err));
+    }
+
+    while let Some(result) = guard.frames.recv().await {
+        let bytes = match result {
+            Ok(bytes) => bytes,
+            Err(err) => return Err(finish_body_stream_error(handle, err)),
+        };
+        guard.capacity.add_permits(buffer_permits(bytes.len()) as usize);
         total_len += bytes.len();
         if let Some(state) = BODY_EVENT_STATES.get(&handle) {
             emit_body_progress(&state, bytes.len() as u64);
@@ -542,20 +645,7 @@ pub async fn read_body_all(handle: u64) -> Result<Bytes> {
         emit_body_complete(&state);
     }
 
-    // Fast path: single chunk or empty
-    if chunks.is_empty() {
-        return Ok(Bytes::new());
-    }
-    if chunks.len() == 1 {
-        return Ok(chunks.into_iter().next().unwrap());
-    }
-
-    // Multiple chunks: consolidate
-    let mut buf = Vec::with_capacity(total_len);
-    for chunk in chunks {
-        buf.extend_from_slice(&chunk);
-    }
-    Ok(Bytes::from(buf))
+    Ok(concat_chunks(chunks, total_len))
 }
 
 pub fn drop_body_stream(handle: u64) {

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -6,6 +6,7 @@ use moka::sync::Cache;
 use std::borrow::Cow;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::task::Poll;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -44,17 +45,19 @@ static TRANSPORT_MANAGER: LazyLock<TransportManager> = LazyLock::new(TransportMa
 const INLINE_BODY_MAX: u64 = 2 * 1024 * 1024;
 
 // Bodies whose length is unknown up front (chunked transfer, or any compressed
-// response, since decoding drops Content-Length) are buffered opportunistically:
-// frames that arrive within this window are collected, and if the body completes
-// under INLINE_BODY_MAX it is inlined exactly like a known-length body. Otherwise
-// the collected prefix is replayed ahead of the live stream through a body handle,
-// so streaming responses pay at most this much extra first-byte latency.
-const INLINE_BODY_WINDOW: Duration = Duration::from_millis(10);
+// response, since decoding drops Content-Length) are inlined opportunistically:
+// frames hyper has already delivered are collected without waiting on the network,
+// and if that completes the body under INLINE_BODY_MAX it is inlined exactly like a
+// known-length body. Otherwise the collected prefix is replayed ahead of the live
+// stream through a body handle. This mirrors Bun's fetch, which inlines a body only
+// when it has fully arrived by the time the response reaches JS, so streaming
+// responses never sit behind a timer.
 
 enum BufferedBody {
-    /// The whole body arrived within the window and fits the inline limit.
+    /// The whole body had already arrived and fits the inline limit.
     Complete(Bytes),
-    /// Frames collected before the window closed or the limit was exceeded.
+    /// Frames that were already available before the stream went pending or the
+    /// limit was exceeded.
     Partial(Vec<Bytes>),
 }
 
@@ -72,24 +75,53 @@ fn concat_chunks(chunks: Vec<Bytes>, total_len: usize) -> Bytes {
     }
 }
 
-async fn buffer_unknown_length_body(stream: &mut ResponseBodyStream) -> wreq::Result<BufferedBody> {
-    let deadline = tokio::time::Instant::now() + INLINE_BODY_WINDOW;
+enum Drain {
+    Complete(Bytes),
+    LimitExceeded,
+    Pending,
+}
+
+/// Drain whatever the body stream can yield right now, never waiting on the network.
+///
+/// hyper hands the response to us as soon as the headers are parsed, while the
+/// connection task is often still delivering body frames it already has in its
+/// buffer (for chunked transfer the terminating chunk always needs one more poll).
+/// A single `yield_now` lets that task finish before we decide, which is a scheduler
+/// hop measured in microseconds, not a wait on I/O.
+async fn buffer_ready_body(stream: &mut ResponseBodyStream) -> wreq::Result<BufferedBody> {
     let mut chunks: Vec<Bytes> = Vec::new();
     let mut total_len = 0usize;
+    let mut yielded = false;
 
     loop {
-        // `Next` is cancel-safe: a timed-out poll leaves the body stream intact.
-        match tokio::time::timeout_at(deadline, stream.next()).await {
-            Ok(Some(Ok(bytes))) => {
-                total_len += bytes.len();
-                chunks.push(bytes);
-                if total_len as u64 > INLINE_BODY_MAX {
-                    return Ok(BufferedBody::Partial(chunks));
+        let drained = std::future::poll_fn(|cx| loop {
+            match stream.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    total_len += bytes.len();
+                    chunks.push(bytes);
+                    if total_len as u64 > INLINE_BODY_MAX {
+                        return Poll::Ready(Ok(Drain::LimitExceeded));
+                    }
                 }
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Err(err)),
+                Poll::Ready(None) => {
+                    let chunks = std::mem::take(&mut chunks);
+                    return Poll::Ready(Ok(Drain::Complete(concat_chunks(chunks, total_len))));
+                }
+                // The stream registered our waker, but we are not going to wait for it.
+                Poll::Pending => return Poll::Ready(Ok(Drain::Pending)),
             }
-            Ok(Some(Err(err))) => return Err(err),
-            Ok(None) => return Ok(BufferedBody::Complete(concat_chunks(chunks, total_len))),
-            Err(_elapsed) => return Ok(BufferedBody::Partial(chunks)),
+        })
+        .await?;
+
+        match drained {
+            Drain::Complete(bytes) => return Ok(BufferedBody::Complete(bytes)),
+            Drain::LimitExceeded => return Ok(BufferedBody::Partial(chunks)),
+            Drain::Pending if !yielded => {
+                yielded = true;
+                tokio::task::yield_now().await;
+            }
+            Drain::Pending => return Ok(BufferedBody::Partial(chunks)),
         }
     }
 }
@@ -814,15 +846,6 @@ async fn make_request_inner(
 
     let allows_body = response_allows_body(status, method.as_ref());
 
-    // Event streams are consumed incrementally by design; never hold their first
-    // bytes back, even for the short inline window.
-    let is_event_stream = response
-        .headers()
-        .get(wreq::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .map(|value| value.trim_start().to_ascii_lowercase().starts_with("text/event-stream"))
-        .unwrap_or(false);
-
     let emit_inline_events = |bytes_len: u64, content_length: Option<u64>| {
         if let Some(sink) = event_sink.as_ref() {
             sink(RequestEvent::BodyProgress {
@@ -856,8 +879,8 @@ async fn make_request_inner(
         } else {
             let mut stream: ResponseBodyStream = Box::pin(response.bytes_stream());
 
-            let buffered = if content_length.is_none() && !is_event_stream {
-                buffer_unknown_length_body(&mut stream).await?
+            let buffered = if content_length.is_none() {
+                buffer_ready_body(&mut stream).await?
             } else {
                 BufferedBody::Partial(Vec::new())
             };

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -189,7 +189,7 @@ impl SessionConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct TransportConfig {
     browser: Option<BrowserEmulation>,
     browser_os: Option<BrowserEmulationOS>,
@@ -280,6 +280,10 @@ struct SessionEntry {
 
 struct TransportManager {
     explicit: DashMap<String, Arc<TransportEntry>>,
+    // Pooled clients for requests that name a session by id without an explicit
+    // transport. Keyed by session id so sessions never share connections or TLS
+    // session state, and by config so per-request overrides get their own client.
+    implicit: Cache<(String, TransportConfig), Arc<ResolvedClient>>,
 }
 
 struct SessionManager {
@@ -476,7 +480,34 @@ impl TransportManager {
     fn new() -> Self {
         Self {
             explicit: DashMap::new(),
+            implicit: Cache::builder()
+                .time_to_idle(Duration::from_secs(300))
+                .support_invalidation_closures()
+                .build(),
         }
+    }
+
+    fn implicit_client_for(
+        &self,
+        session_id: &str,
+        config: TransportConfig,
+    ) -> Result<Arc<ResolvedClient>> {
+        let key = (session_id.to_owned(), config);
+        if let Some(resolved) = self.implicit.get(&key) {
+            return Ok(resolved);
+        }
+
+        let resolved = Arc::new(build_client(&key.1)?);
+        self.implicit.insert(key, resolved.clone());
+        Ok(resolved)
+    }
+
+    fn drop_implicit_clients(&self, session_id: &str) {
+        let session_id = session_id.to_owned();
+        // Only fails if the cache was built without closure invalidation support.
+        let _ = self
+            .implicit
+            .invalidate_entries_if(move |key, _| key.0 == session_id);
     }
 
     fn create_transport(&self, config: TransportConfig) -> Result<String> {
@@ -565,7 +596,7 @@ impl EphemeralClientManager {
 pub async fn make_request(options: RequestOptions) -> Result<Response> {
     let transport_id = options.transport_id.clone();
 
-    // Resolve client: explicit transport > ephemeral cache > fresh client
+    // Resolve client: explicit transport > ephemeral cache > per-session implicit cache
     let resolved = if let Some(ref tid) = transport_id {
         TRANSPORT_MANAGER.get_transport(tid)?
     } else if options.ephemeral {
@@ -573,7 +604,7 @@ pub async fn make_request(options: RequestOptions) -> Result<Response> {
         EPHEMERAL_MANAGER.client_for(config)?
     } else {
         let config = TransportConfig::from_request(&options);
-        Arc::new(build_client(&config)?)
+        TRANSPORT_MANAGER.implicit_client_for(&options.session_id, config)?
     };
 
     // Resolve cookie jar: ephemeral gets a fresh jar, sessions share one
@@ -928,6 +959,7 @@ pub fn clear_managed_session(session_id: &str) -> Result<()> {
 
 pub fn drop_managed_session(session_id: &str) {
     SESSION_MANAGER.drop_session(session_id);
+    TRANSPORT_MANAGER.drop_implicit_clients(session_id);
 }
 
 pub fn create_managed_transport(

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -370,7 +370,11 @@ struct TransportManager {
 }
 
 struct SessionManager {
-    cache: Cache<String, Arc<SessionEntry>>,
+    // Cookie jars live until dropSession(), which Session.close() and the JS
+    // finalizer for unreferenced Session objects both call. They used to sit in an
+    // idle-expiring cache, which silently handed any session that had been quiet
+    // for five minutes a fresh, empty jar on its next request.
+    sessions: DashMap<String, Arc<SessionEntry>>,
 }
 
 struct EphemeralClientManager {
@@ -616,21 +620,24 @@ impl TransportManager {
 impl SessionManager {
     fn new() -> Self {
         Self {
-            cache: Cache::builder()
-                .time_to_idle(Duration::from_secs(300))
-                .build(),
+            sessions: DashMap::new(),
         }
     }
 
     fn jar_for(&self, session_id: &str) -> Result<Arc<Jar>> {
-        if let Some(entry) = self.cache.get(session_id) {
+        if let Some(entry) = self.sessions.get(session_id) {
             return Ok(entry.cookie_jar.clone());
         }
 
-        let entry = Arc::new(SessionEntry {
-            cookie_jar: Arc::new(Jar::default()),
-        });
-        self.cache.insert(session_id.to_string(), entry.clone());
+        let entry = self
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(|| {
+                Arc::new(SessionEntry {
+                    cookie_jar: Arc::new(Jar::default()),
+                })
+            })
+            .clone();
         Ok(entry.cookie_jar.clone())
     }
 
@@ -638,13 +645,13 @@ impl SessionManager {
         let entry = Arc::new(SessionEntry {
             cookie_jar: Arc::new(Jar::default()),
         });
-        self.cache.insert(session_id.clone(), entry);
+        self.sessions.insert(session_id.clone(), entry);
         Ok(session_id)
     }
 
     fn clear_session(&self, session_id: &str) -> Result<()> {
         let entry = self
-            .cache
+            .sessions
             .get(session_id)
             .ok_or_else(|| anyhow::anyhow!("Session '{}' not found", session_id))?;
         entry.cookie_jar.clear();
@@ -652,7 +659,7 @@ impl SessionManager {
     }
 
     fn drop_session(&self, session_id: &str) {
-        self.cache.invalidate(session_id);
+        self.sessions.remove(session_id);
     }
 }
 
@@ -1129,6 +1136,21 @@ mod tests {
         include_str!("../../src/test/helpers/certs/default-paths-leaf.crt");
 
     static ENV_LOCK: LazyLock<StdMutex<()>> = LazyLock::new(|| StdMutex::new(()));
+
+    #[test]
+    fn managed_sessions_keep_their_jar_until_dropped() {
+        let id = format!("lifetime-{}", Uuid::new_v4());
+        create_managed_session(id.clone()).expect("create session");
+
+        let first = get_session_cookie_jar(&id).expect("jar");
+        let again = get_session_cookie_jar(&id).expect("jar again");
+        assert!(Arc::ptr_eq(&first, &again), "the jar must persist across lookups");
+
+        drop_managed_session(&id);
+        let fresh = get_session_cookie_jar(&id).expect("jar after drop");
+        assert!(!Arc::ptr_eq(&first, &fresh), "dropping the session must release its jar");
+        drop_managed_session(&id);
+    }
 
     #[test]
     fn cookie_origin_uri_maps_websocket_schemes_to_http() {

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
 use dashmap::DashMap;
-use futures_util::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt, stream};
 use moka::sync::Cache;
 use std::borrow::Cow;
 use std::net::SocketAddr;
@@ -42,6 +42,57 @@ static TRANSPORT_MANAGER: LazyLock<TransportManager> = LazyLock::new(TransportMa
 // Most API responses fit within 2 MiB; inlining them skips DashMap, Mutex, and an
 // additional FFI round-trip that the streaming path would otherwise require.
 const INLINE_BODY_MAX: u64 = 2 * 1024 * 1024;
+
+// Bodies whose length is unknown up front (chunked transfer, or any compressed
+// response, since decoding drops Content-Length) are buffered opportunistically:
+// frames that arrive within this window are collected, and if the body completes
+// under INLINE_BODY_MAX it is inlined exactly like a known-length body. Otherwise
+// the collected prefix is replayed ahead of the live stream through a body handle,
+// so streaming responses pay at most this much extra first-byte latency.
+const INLINE_BODY_WINDOW: Duration = Duration::from_millis(10);
+
+enum BufferedBody {
+    /// The whole body arrived within the window and fits the inline limit.
+    Complete(Bytes),
+    /// Frames collected before the window closed or the limit was exceeded.
+    Partial(Vec<Bytes>),
+}
+
+fn concat_chunks(chunks: Vec<Bytes>, total_len: usize) -> Bytes {
+    match chunks.len() {
+        0 => Bytes::new(),
+        1 => chunks.into_iter().next().unwrap(),
+        _ => {
+            let mut buf = Vec::with_capacity(total_len);
+            for chunk in chunks {
+                buf.extend_from_slice(&chunk);
+            }
+            Bytes::from(buf)
+        }
+    }
+}
+
+async fn buffer_unknown_length_body(stream: &mut ResponseBodyStream) -> wreq::Result<BufferedBody> {
+    let deadline = tokio::time::Instant::now() + INLINE_BODY_WINDOW;
+    let mut chunks: Vec<Bytes> = Vec::new();
+    let mut total_len = 0usize;
+
+    loop {
+        // `Next` is cancel-safe: a timed-out poll leaves the body stream intact.
+        match tokio::time::timeout_at(deadline, stream.next()).await {
+            Ok(Some(Ok(bytes))) => {
+                total_len += bytes.len();
+                chunks.push(bytes);
+                if total_len as u64 > INLINE_BODY_MAX {
+                    return Ok(BufferedBody::Partial(chunks));
+                }
+            }
+            Ok(Some(Err(err))) => return Err(err),
+            Ok(None) => return Ok(BufferedBody::Complete(concat_chunks(chunks, total_len))),
+            Err(_elapsed) => return Ok(BufferedBody::Partial(chunks)),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum TrustStoreMode {
@@ -763,6 +814,35 @@ async fn make_request_inner(
 
     let allows_body = response_allows_body(status, method.as_ref());
 
+    // Event streams are consumed incrementally by design; never hold their first
+    // bytes back, even for the short inline window.
+    let is_event_stream = response
+        .headers()
+        .get(wreq::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim_start().to_ascii_lowercase().starts_with("text/event-stream"))
+        .unwrap_or(false);
+
+    let emit_inline_events = |bytes_len: u64, content_length: Option<u64>| {
+        if let Some(sink) = event_sink.as_ref() {
+            sink(RequestEvent::BodyProgress {
+                timestamp_ms: start.elapsed().as_millis() as u64,
+                downloaded_bytes: bytes_len,
+                content_length,
+            });
+            sink(RequestEvent::BodyComplete {
+                timestamp_ms: start.elapsed().as_millis() as u64,
+                downloaded_bytes: bytes_len,
+                content_length,
+            });
+            sink(RequestEvent::Done {
+                timestamp_ms: start.elapsed().as_millis() as u64,
+                status,
+                url: final_url.clone(),
+            });
+        }
+    };
+
     let (body_handle, body_bytes) = if allows_body {
         let inline_eligible = content_length
             .map(|len| len <= INLINE_BODY_MAX)
@@ -771,40 +851,45 @@ async fn make_request_inner(
         if inline_eligible {
             let bytes = response.bytes().await?;
             content_length = Some(bytes.len() as u64);
-            if let Some(sink) = event_sink.as_ref() {
-                sink(RequestEvent::BodyProgress {
-                    timestamp_ms: start.elapsed().as_millis() as u64,
-                    downloaded_bytes: bytes.len() as u64,
-                    content_length,
-                });
-                sink(RequestEvent::BodyComplete {
-                    timestamp_ms: start.elapsed().as_millis() as u64,
-                    downloaded_bytes: bytes.len() as u64,
-                    content_length,
-                });
-                sink(RequestEvent::Done {
-                    timestamp_ms: start.elapsed().as_millis() as u64,
-                    status,
-                    url: final_url.clone(),
-                });
-            }
+            emit_inline_events(bytes.len() as u64, content_length);
             (None, Some(bytes))
         } else {
-            let stream: ResponseBodyStream = Box::pin(response.bytes_stream());
-            let handle = store_body_stream(stream);
-            if let Some(sink) = event_sink.as_ref() {
-                BODY_EVENT_STATES.insert(
-                    handle,
-                    BodyEventState {
-                        sink: sink.clone(),
-                        content_length,
-                        downloaded_bytes: Arc::new(AtomicU64::new(0)),
-                        status,
-                        url: final_url.clone(),
-                    },
-                );
+            let mut stream: ResponseBodyStream = Box::pin(response.bytes_stream());
+
+            let buffered = if content_length.is_none() && !is_event_stream {
+                buffer_unknown_length_body(&mut stream).await?
+            } else {
+                BufferedBody::Partial(Vec::new())
+            };
+
+            match buffered {
+                BufferedBody::Complete(bytes) => {
+                    content_length = Some(bytes.len() as u64);
+                    emit_inline_events(bytes.len() as u64, content_length);
+                    (None, Some(bytes))
+                }
+                BufferedBody::Partial(prefix) => {
+                    let stream: ResponseBodyStream = if prefix.is_empty() {
+                        stream
+                    } else {
+                        Box::pin(stream::iter(prefix.into_iter().map(Ok)).chain(stream))
+                    };
+                    let handle = store_body_stream(stream);
+                    if let Some(sink) = event_sink.as_ref() {
+                        BODY_EVENT_STATES.insert(
+                            handle,
+                            BodyEventState {
+                                sink: sink.clone(),
+                                content_length,
+                                downloaded_bytes: Arc::new(AtomicU64::new(0)),
+                                status,
+                                url: final_url.clone(),
+                            },
+                        );
+                    }
+                    (Some(handle), None)
+                }
             }
-            (Some(handle), None)
         }
     } else {
         if let Some(sink) = event_sink.as_ref() {

--- a/rust/src/external_buffer.rs
+++ b/rust/src/external_buffer.rs
@@ -1,0 +1,158 @@
+//! Hand large response bodies to JS without copying them.
+//!
+//! `napi_create_external_buffer` wraps a Rust allocation in a `Buffer` and frees it
+//! through a finalizer when the JS object is collected. That skips the zero-fill and
+//! memcpy of `napi_create_buffer_copy`, which the profile showed as the two largest
+//! costs of settling a large body, and it halves peak memory because the bytes no
+//! longer exist twice while both copies are alive.
+//!
+//! Runtimes built with V8's sandbox (Electron) refuse external buffers with
+//! `napi_no_external_buffers_allowed`. neon's `JsBuffer::external` unwraps that
+//! status, so the function is resolved here directly and probed once at module load;
+//! when refused, every body falls back to a copy, as napi-rs does.
+//!
+//! The sizes are deliberately not reported through `napi_adjust_external_memory`.
+//! Node's V8 already accounts external backing stores. On Bun, JSC cannot see the
+//! bytes at all, and reporting them made things worse: it scales its next collection
+//! threshold by the reported size, so peak memory grew to gigabytes instead of
+//! shrinking. The JS side therefore keeps external buffers off on Bun (see
+//! `configureRuntime`), where every body is copied as before.
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use bytes::Bytes;
+use neon::prelude::*;
+use neon::sys::bindings::{Env as RawEnv, Value as RawValue};
+
+/// Bodies at or below this size are copied; the finalizer bookkeeping of an external
+/// buffer costs more than a small memcpy.
+pub const EXTERNAL_BUFFER_MIN: usize = 64 * 1024;
+
+const NAPI_OK: u32 = 0;
+const NAPI_NO_EXTERNAL_BUFFERS_ALLOWED: u32 = 22;
+
+type NapiFinalize = unsafe extern "C" fn(env: RawEnv, data: *mut c_void, hint: *mut c_void);
+type CreateExternalBufferFn = unsafe extern "C" fn(
+    env: RawEnv,
+    length: usize,
+    data: *mut c_void,
+    finalize_cb: Option<NapiFinalize>,
+    finalize_hint: *mut c_void,
+    result: *mut RawValue,
+) -> u32;
+struct NapiFns {
+    create_external_buffer: CreateExternalBufferFn,
+}
+
+static NAPI: OnceLock<Option<NapiFns>> = OnceLock::new();
+static ALLOWED: AtomicBool = AtomicBool::new(false);
+
+fn resolve_napi() -> Option<NapiFns> {
+    // The host process (node, bun, electron) exports Node-API; look symbols up there,
+    // the same way neon loads its own function table.
+    #[cfg(unix)]
+    let host = libloading::os::unix::Library::this();
+    #[cfg(windows)]
+    let host = libloading::os::windows::Library::this().ok()?;
+
+    // SAFETY: the symbol signatures match the Node-API C declarations.
+    let create_external_buffer = unsafe {
+        host.get::<CreateExternalBufferFn>(b"napi_create_external_buffer\0")
+            .ok()
+            .map(|symbol| *symbol)?
+    };
+    // Symbols from the host program stay valid for the life of the process.
+    std::mem::forget(host);
+
+    Some(NapiFns {
+        create_external_buffer,
+    })
+}
+
+unsafe extern "C" fn drop_vec(_env: RawEnv, _data: *mut c_void, hint: *mut c_void) {
+    // SAFETY: `hint` is the Box<Vec<u8>> handed to napi_create_external_buffer below,
+    // and the runtime calls this exactly once when the buffer is collected.
+    drop(unsafe { Box::<Vec<u8>>::from_raw(hint.cast()) });
+}
+
+enum Created {
+    Buffer(RawValue),
+    /// The runtime refused external buffers; the data comes back for copying.
+    Refused(Vec<u8>),
+    Failed(u32),
+}
+
+/// Try to wrap `data` in an external buffer.
+unsafe fn create_external(env: RawEnv, data: Vec<u8>) -> Created {
+    let Some(Some(fns)) = NAPI.get() else {
+        return Created::Refused(data);
+    };
+
+    // Box first so the Vec header has a stable address to hand to the finalizer.
+    let mut boxed = Box::new(data);
+    let ptr = boxed.as_mut_ptr().cast::<c_void>();
+    let len = boxed.len();
+    let hint = Box::into_raw(boxed);
+    let finalize: NapiFinalize = drop_vec;
+    let mut result: RawValue = std::ptr::null_mut();
+
+    // SAFETY: `env` is valid for this thread; on failure the runtime has not taken
+    // ownership, so the Box is reclaimed below.
+    let status = unsafe { (fns.create_external_buffer)(env, len, ptr, Some(finalize), hint.cast(), &mut result) };
+
+    if status != NAPI_OK {
+        let data = *unsafe { Box::from_raw(hint) };
+        return if status == NAPI_NO_EXTERNAL_BUFFERS_ALLOWED {
+            Created::Refused(data)
+        } else {
+            Created::Failed(status)
+        };
+    }
+
+    Created::Buffer(result)
+}
+
+/// Resolve the Node-API symbols and probe once whether this runtime accepts external
+/// buffers. Called from module initialization.
+pub fn init<'cx, C: Context<'cx>>(cx: &mut C) {
+    let fns = NAPI.get_or_init(resolve_napi);
+    if fns.is_none() {
+        return;
+    }
+    let env = cx.to_raw();
+    // SAFETY: called on the JS thread during module init with a valid env.
+    let allowed = matches!(unsafe { create_external(env, vec![0u8]) }, Created::Buffer(_));
+    ALLOWED.store(allowed, Ordering::Relaxed);
+}
+
+/// Allow JS to turn external buffers off for a runtime where they misbehave.
+pub fn set_enabled(enabled: bool) {
+    if !enabled {
+        ALLOWED.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Convert body bytes to a JS `Buffer`: external (zero-copy when the `Bytes` uniquely
+/// owns its allocation) above the threshold, copied otherwise.
+pub fn bytes_to_js_buffer<'cx, C: Context<'cx>>(cx: &mut C, bytes: Bytes) -> JsResult<'cx, JsBuffer> {
+    if bytes.len() < EXTERNAL_BUFFER_MIN || !ALLOWED.load(Ordering::Relaxed) {
+        return JsBuffer::from_slice(cx, &bytes);
+    }
+
+    let owned: Vec<u8> = bytes.into();
+    // SAFETY: on the JS thread with the context's env.
+    match unsafe { create_external(cx.to_raw(), owned) } {
+        // SAFETY: the runtime just returned this value as a Buffer for this env.
+        Created::Buffer(value) => Ok(unsafe { JsBuffer::from_raw(cx, value) }),
+        Created::Refused(data) => {
+            // The runtime changed its mind (or the probe was wrong); copy from now on.
+            ALLOWED.store(false, Ordering::Relaxed);
+            JsBuffer::from_slice(cx, &data)
+        }
+        Created::Failed(status) => {
+            cx.throw_error(format!("napi_create_external_buffer failed with status {status}"))
+        }
+    }
+}

--- a/rust/src/external_buffer.rs
+++ b/rust/src/external_buffer.rs
@@ -1,8 +1,8 @@
 //! Hand large response bodies to JS without copying them.
 //!
 //! `napi_create_external_buffer` wraps a Rust allocation in a `Buffer` and frees it
-//! through a finalizer when the JS object is collected. That skips the zero-fill and
-//! memcpy of `napi_create_buffer_copy`. Peak memory still depends on allocation
+//! through a finalizer when the JS object is collected. That skips copying the
+//! body into a runtime-owned buffer. Peak memory still depends on allocation
 //! sizes, request rate, and the runtime's garbage collection behavior.
 //!
 //! Runtimes built with V8's sandbox (Electron) refuse external buffers with
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use bytes::Bytes;
 use neon::prelude::*;
 use neon::sys::bindings::{Env as RawEnv, Value as RawValue};
+use neon::types::buffer::TypedArray;
 
 /// Smaller buffers are copied: equal-rate Node benchmarks showed lower resident
 /// memory at 64 KiB with negligible throughput differences. Keep larger buffers
@@ -100,7 +101,9 @@ unsafe fn create_external(env: RawEnv, data: Vec<u8>) -> Created {
 
     // SAFETY: `env` is valid for this thread; on failure the runtime has not taken
     // ownership, so the Box is reclaimed below.
-    let status = unsafe { (fns.create_external_buffer)(env, len, ptr, Some(finalize), hint.cast(), &mut result) };
+    let status = unsafe {
+        (fns.create_external_buffer)(env, len, ptr, Some(finalize), hint.cast(), &mut result)
+    };
 
     if status != NAPI_OK {
         let data = *unsafe { Box::from_raw(hint) };
@@ -123,7 +126,10 @@ pub fn init<'cx, C: Context<'cx>>(cx: &mut C) {
     }
     let env = cx.to_raw();
     // SAFETY: called on the JS thread during module init with a valid env.
-    let allowed = matches!(unsafe { create_external(env, vec![0u8]) }, Created::Buffer(_));
+    let allowed = matches!(
+        unsafe { create_external(env, vec![0u8]) },
+        Created::Buffer(_)
+    );
     ALLOWED.store(allowed, Ordering::Relaxed);
 }
 
@@ -136,9 +142,12 @@ pub fn set_enabled(enabled: bool) {
 
 /// Convert body bytes to a JS `Buffer`: external (zero-copy when the `Bytes` uniquely
 /// owns its allocation) above the threshold, copied otherwise.
-pub fn bytes_to_js_buffer<'cx, C: Context<'cx>>(cx: &mut C, bytes: Bytes) -> JsResult<'cx, JsBuffer> {
+pub fn bytes_to_js_buffer<'cx, C: Context<'cx>>(
+    cx: &mut C,
+    bytes: Bytes,
+) -> JsResult<'cx, JsBuffer> {
     if bytes.len() < EXTERNAL_BUFFER_MIN || !ALLOWED.load(Ordering::Relaxed) {
-        return JsBuffer::from_slice(cx, &bytes);
+        return copy_buffer(cx, &bytes);
     }
 
     let owned: Vec<u8> = bytes.into();
@@ -149,10 +158,18 @@ pub fn bytes_to_js_buffer<'cx, C: Context<'cx>>(cx: &mut C, bytes: Bytes) -> JsR
         Created::Refused(data) => {
             // The runtime changed its mind (or the probe was wrong); copy from now on.
             ALLOWED.store(false, Ordering::Relaxed);
-            JsBuffer::from_slice(cx, &data)
+            copy_buffer(cx, &data)
         }
-        Created::Failed(status) => {
-            cx.throw_error(format!("napi_create_external_buffer failed with status {status}"))
-        }
+        Created::Failed(status) => cx.throw_error(format!(
+            "napi_create_external_buffer failed with status {status}"
+        )),
     }
+}
+
+fn copy_buffer<'cx, C: Context<'cx>>(cx: &mut C, bytes: &[u8]) -> JsResult<'cx, JsBuffer> {
+    // SAFETY: every byte is initialized immediately, before the buffer is exposed
+    // to JavaScript. Avoid zero-filling memory that the copy will overwrite.
+    let mut buffer = unsafe { JsBuffer::uninitialized(cx, bytes.len())? };
+    buffer.as_mut_slice(cx).copy_from_slice(bytes);
+    Ok(buffer)
 }

--- a/rust/src/external_buffer.rs
+++ b/rust/src/external_buffer.rs
@@ -2,9 +2,8 @@
 //!
 //! `napi_create_external_buffer` wraps a Rust allocation in a `Buffer` and frees it
 //! through a finalizer when the JS object is collected. That skips the zero-fill and
-//! memcpy of `napi_create_buffer_copy`, which the profile showed as the two largest
-//! costs of settling a large body, and it halves peak memory because the bytes no
-//! longer exist twice while both copies are alive.
+//! memcpy of `napi_create_buffer_copy`. Peak memory still depends on allocation
+//! sizes, request rate, and the runtime's garbage collection behavior.
 //!
 //! Runtimes built with V8's sandbox (Electron) refuse external buffers with
 //! `napi_no_external_buffers_allowed`. neon's `JsBuffer::external` unwraps that
@@ -26,9 +25,10 @@ use bytes::Bytes;
 use neon::prelude::*;
 use neon::sys::bindings::{Env as RawEnv, Value as RawValue};
 
-/// Bodies at or below this size are copied; the finalizer bookkeeping of an external
-/// buffer costs more than a small memcpy.
-pub const EXTERNAL_BUFFER_MIN: usize = 64 * 1024;
+/// Smaller buffers are copied: equal-rate Node benchmarks showed lower resident
+/// memory at 64 KiB with negligible throughput differences. Keep larger buffers
+/// external to retain the throughput and CPU benefits on large full-body reads.
+pub const EXTERNAL_BUFFER_MIN: usize = 256 * 1024;
 
 const NAPI_OK: u32 = 0;
 const NAPI_NO_EXTERNAL_BUFFERS_ALLOWED: u32 = 22;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -238,191 +238,6 @@ fn parse_resolve_opt(
 }
 
 // Convert JS object to RequestOptions
-fn js_object_to_request_options(
-    cx: &mut FunctionContext,
-    obj: Handle<JsObject>,
-    event_sink: Option<client::RequestEventSink>,
-) -> NeonResult<RequestOptions> {
-    // Get URL (required)
-    let url: Handle<JsString> = obj.get(cx, "url")?;
-    let url = url.value(cx);
-
-    // Get browser/os/emulation mode as resolved by JS.
-    let browser_str = obj
-        .get_opt(cx, "browser")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| v.value(cx));
-
-    let browser = browser_str.as_deref().map(parse_emulation);
-    let os_str = obj
-        .get_opt(cx, "os")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| v.value(cx));
-    let browser_os = os_str.as_deref().map(parse_emulation_os);
-    let emulation_json = obj
-        .get_opt(cx, "emulationJson")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| Arc::<str>::from(v.value(cx)));
-
-    // Get method (optional, defaults to GET)
-    let method = obj
-        .get_opt(cx, "method")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or_else(|| "GET".to_string());
-
-    // Get headers (optional)
-    let headers = if let Ok(Some(headers_val)) = obj.get_opt(cx, "headers") {
-        parse_headers_from_value(cx, headers_val)?
-    } else {
-        Vec::new()
-    };
-
-    // Get body (optional)
-    let body = if let Some(body_value) = obj.get_opt::<JsValue, _, _>(cx, "body")? {
-        if body_value.is_a::<JsUndefined, _>(cx) || body_value.is_a::<JsNull, _>(cx) {
-            None
-        } else if let Ok(buffer) = body_value.downcast::<JsBuffer, _>(cx) {
-            Some(buffer.as_slice(cx).to_vec())
-        } else if let Ok(js_str) = body_value.downcast::<JsString, _>(cx) {
-            Some(js_str.value(cx).into_bytes())
-        } else {
-            return cx.throw_type_error("body must be a string or Buffer");
-        }
-    } else {
-        None
-    };
-
-    // Get proxy (optional)
-    let proxy = obj
-        .get_opt(cx, "proxy")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| Arc::<str>::from(v.value(cx)));
-
-    // Get timeout (optional, defaults to 30000ms)
-    let timeout = obj
-        .get_opt(cx, "timeout")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
-        .map(|v| v.value(cx) as u64)
-        .unwrap_or(30000);
-
-    // Get redirect policy (optional, defaults to follow)
-    let redirect = obj
-        .get_opt(cx, "redirect")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or_else(|| "follow".to_string());
-
-    let redirect = match redirect.as_str() {
-        "follow" => RedirectMode::Follow,
-        "manual" => RedirectMode::Manual,
-        "error" => RedirectMode::Error,
-        other => return cx.throw_type_error(format!("Unsupported redirect mode: {}", other)),
-    };
-
-    // Get sessionId (optional)
-    let session_id = obj
-        .get_opt(cx, "sessionId")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(generate_session_id);
-
-    let ephemeral = obj
-        .get_opt(cx, "ephemeral")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or(false);
-
-    let disable_default_headers = obj
-        .get_opt(cx, "disableDefaultHeaders")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or(false);
-
-    let insecure = obj
-        .get_opt(cx, "insecure")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or(false);
-
-    let trust_store = obj
-        .get_opt(cx, "trustStore")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| parse_trust_store_mode(&v.value(cx)))
-        .unwrap_or_default();
-
-    let compress = obj
-        .get_opt(cx, "compress")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or(true);
-
-    let transport_id = obj
-        .get_opt(cx, "transportId")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .filter(|v| !v.trim().is_empty());
-
-    let capture_diagnostics = obj
-        .get_opt(cx, "captureDiagnostics")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsBoolean, _>(cx).ok())
-        .map(|v| v.value(cx))
-        .unwrap_or(false);
-
-    let pool_idle_timeout = obj
-        .get_opt(cx, "poolIdleTimeout")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
-        .map(|v| v.value(cx) as u64);
-
-    let pool_max_idle_per_host = obj
-        .get_opt(cx, "poolMaxIdlePerHost")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
-        .map(|v| v.value(cx) as usize);
-
-    let pool_max_size = obj
-        .get_opt(cx, "poolMaxSize")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
-        .map(|v| v.value(cx) as u32);
-
-    let connect_timeout = obj
-        .get_opt(cx, "connectTimeout")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
-        .map(|v| v.value(cx) as u64);
-
-    let read_timeout = obj
-        .get_opt(cx, "readTimeout")?
-        .and_then(|v: Handle<JsValue>| v.downcast::<JsNumber, _>(cx).ok())
-        .map(|v| v.value(cx) as u64);
-
-    Ok(RequestOptions {
-        url,
-        browser,
-        browser_os,
-        emulation_json,
-        headers,
-        method,
-        body,
-        proxy,
-        timeout,
-        redirect,
-        session_id,
-        ephemeral,
-        disable_default_headers,
-        insecure,
-        trust_store,
-        transport_id,
-        pool_idle_timeout,
-        pool_max_idle_per_host,
-        pool_max_size,
-        connect_timeout,
-        read_timeout,
-        compress,
-        capture_diagnostics,
-        event_sink,
-    })
-}
-
 // Convert Response to JS object
 fn response_to_js_object<'a, C: Context<'a>>(
     cx: &mut C,
@@ -438,61 +253,44 @@ fn response_to_js_object<'a, C: Context<'a>>(
     let url = cx.string(&response.url);
     obj.set(cx, "url", url)?;
 
-    // Headers
-    let headers_arr = cx.empty_array();
+    // Headers as a flat [name, value, name, value, ...] array, the shape Node's own
+    // HTTP parser hands up as rawHeaders: two element stores per header instead of an
+    // array allocation plus three stores.
+    let headers_arr = JsArray::new(cx, response.headers.len() * 2);
     for (i, (key, value)) in response.headers.iter().enumerate() {
-        let entry = cx.empty_array();
         let key_str = cx.string(key);
         let value_str = cx.string(value);
-        entry.set(cx, 0, key_str)?;
-        entry.set(cx, 1, value_str)?;
-        headers_arr.set(cx, i as u32, entry)?;
+        headers_arr.set(cx, (i * 2) as u32, key_str)?;
+        headers_arr.set(cx, (i * 2 + 1) as u32, value_str)?;
     }
     obj.set(cx, "headers", headers_arr)?;
 
-    // Cookies (as array of [key, value] tuples)
-    let cookies_arr = cx.empty_array();
-    for (i, (key, value)) in response.cookies.iter().enumerate() {
-        let entry = cx.empty_array();
-        let key_str = cx.string(key);
-        let value_str = cx.string(value);
-        entry.set(cx, 0, key_str)?;
-        entry.set(cx, 1, value_str)?;
-        cookies_arr.set(cx, i as u32, entry)?;
-    }
-    obj.set(cx, "cookies", cookies_arr)?;
-
-    // Inline body bytes for small responses (avoids a second native round-trip)
-    match response.body_bytes {
-        Some(bytes) => {
-            let buffer = JsBuffer::from_slice(cx, &bytes)?;
-            obj.set(cx, "bodyBytes", buffer)?;
+    // Cookies, same flat shape; omitted entirely when the response set none.
+    if !response.cookies.is_empty() {
+        let cookies_arr = JsArray::new(cx, response.cookies.len() * 2);
+        for (i, (key, value)) in response.cookies.iter().enumerate() {
+            let key_str = cx.string(key);
+            let value_str = cx.string(value);
+            cookies_arr.set(cx, (i * 2) as u32, key_str)?;
+            cookies_arr.set(cx, (i * 2 + 1) as u32, value_str)?;
         }
-        None => {
-            let null_value = cx.null();
-            obj.set(cx, "bodyBytes", null_value)?;
-        }
+        obj.set(cx, "cookies", cookies_arr)?;
     }
 
-    // Body handle for streaming
-    match response.body_handle {
-        Some(handle) => {
-            let handle_num = cx.number(handle as f64);
-            obj.set(cx, "bodyHandle", handle_num)?;
-        }
-        None => {
-            let null_value = cx.null();
-            obj.set(cx, "bodyHandle", null_value)?;
-        }
+    // Absent fields are left absent rather than set to null; JS reads them with `??`.
+    if let Some(bytes) = response.body_bytes {
+        let buffer = JsBuffer::from_slice(cx, &bytes)?;
+        obj.set(cx, "bodyBytes", buffer)?;
     }
 
-    // Content-Length hint (if known)
+    if let Some(handle) = response.body_handle {
+        let handle_num = cx.number(handle as f64);
+        obj.set(cx, "bodyHandle", handle_num)?;
+    }
+
     if let Some(len) = response.content_length {
         let len_num = cx.number(len as f64);
         obj.set(cx, "contentLength", len_num)?;
-    } else {
-        let null_value = cx.null();
-        obj.set(cx, "contentLength", null_value)?;
     }
 
     // Diagnostics payload (if present)
@@ -525,9 +323,6 @@ fn response_to_js_object<'a, C: Context<'a>>(
             diagnostics_obj.set(cx, "tlsPeerCertificateChainLength", value)?;
         }
         obj.set(cx, "diagnostics", diagnostics_obj)?;
-    } else {
-        let null_value = cx.null();
-        obj.set(cx, "diagnostics", null_value)?;
     }
 
     Ok(obj)
@@ -652,36 +447,171 @@ fn request_event_to_js_object<'a, C: Context<'a>>(
 }
 
 // Main request function exported to Node.js
+// Bit flags for the positional `request()` call. Mirrors how Node's own bindings pass
+// option sets (fs open flags) rather than an object the addon has to probe field by field.
+const FLAG_EPHEMERAL: u32 = 1;
+const FLAG_DISABLE_DEFAULT_HEADERS: u32 = 1 << 1;
+const FLAG_INSECURE: u32 = 1 << 2;
+const FLAG_NO_COMPRESS: u32 = 1 << 3;
+const FLAG_CAPTURE_DIAGNOSTICS: u32 = 1 << 4;
+const FLAG_CANCELLABLE: u32 = 1 << 5;
+const FLAG_REDIRECT_MANUAL: u32 = 1 << 6;
+const FLAG_REDIRECT_ERROR: u32 = 1 << 7;
+
+type RequestArgs<'cx> = (
+    String,                      // url
+    String,                      // method
+    String,                      // sessionId
+    f64,                         // requestId
+    f64,                         // flags
+    f64,                         // timeout ms
+    Option<Handle<'cx, JsArray>>, // headers, flat [name, value, name, value, ...]
+    Option<Handle<'cx, JsValue>>, // body: Buffer | string
+    Option<String>,              // transportId
+    Option<Handle<'cx, JsObject>>, // extras: browser/os/emulationJson/proxy/trustStore/onRequestEvent
+);
+
 fn request(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    // Get the options object
-    let options_obj = cx.argument::<JsObject>(0)?;
-    let request_id = cx.argument::<JsNumber>(1)?.value(&mut cx) as u64;
-    let cancellable = cx
-        .argument_opt(2)
-        .and_then(|value| value.downcast::<JsBoolean, _>(&mut cx).ok())
-        .map(|b| b.value(&mut cx))
-        .unwrap_or(true);
+    // Positional arguments arrive in a single napi_get_cb_info. The previous options
+    // object cost one napi_get_property per field, 24 per request, most of them absent
+    // on the pooled-session hot path. Rarely used fields travel in `extras`, an object
+    // that is only present (and only probed) when one of them is set.
+    let (
+        url,
+        method,
+        session_id,
+        request_id,
+        flags,
+        timeout,
+        headers,
+        body,
+        transport_id,
+        extras,
+    ): RequestArgs = cx.args()?;
 
+    let request_id = request_id as u64;
+    let flags = flags as u32;
+    let cancellable = flags & FLAG_CANCELLABLE != 0;
     let settle_channel = cx.channel();
-    let event_sink = options_obj
-        .get_opt::<JsFunction, _, _>(&mut cx, "onRequestEvent")?
-        .map(|callback| {
-            let callback = Arc::new(callback.root(&mut cx));
-            let channel = settle_channel.clone();
-            Arc::new(move |event: RequestEvent| {
-                let callback = callback.clone();
-                channel.send(move |mut cx| {
-                    let cb = callback.to_inner(&mut cx);
-                    let this = cx.undefined();
-                    let event_obj = request_event_to_js_object(&mut cx, event)?;
-                    cb.call(&mut cx, this, vec![event_obj.upcast()])?;
-                    Ok(())
-                });
-            }) as client::RequestEventSink
-        });
 
-    // Convert JS object to Rust struct
-    let options = js_object_to_request_options(&mut cx, options_obj, event_sink)?;
+    let headers = match headers {
+        Some(flat) => {
+            let flat = flat.to_vec(&mut cx)?;
+            if flat.len() % 2 != 0 {
+                return cx.throw_type_error("headers must be a flat array of name/value pairs");
+            }
+            let mut pairs = Vec::with_capacity(flat.len() / 2);
+            for pair in flat.chunks_exact(2) {
+                let name = coerce_header_value(&mut cx, pair[0])?;
+                let value = coerce_header_value(&mut cx, pair[1])?;
+                pairs.push((name, value));
+            }
+            pairs
+        }
+        None => Vec::new(),
+    };
+
+    let body = match body {
+        None => None,
+        Some(value) => {
+            if let Ok(buffer) = value.downcast::<JsBuffer, _>(&mut cx) {
+                Some(buffer.as_slice(&cx).to_vec())
+            } else if let Ok(js_str) = value.downcast::<JsString, _>(&mut cx) {
+                Some(js_str.value(&mut cx).into_bytes())
+            } else {
+                return cx.throw_type_error("body must be a string or Buffer");
+            }
+        }
+    };
+
+    let mut browser = None;
+    let mut browser_os = None;
+    let mut emulation_json = None;
+    let mut proxy = None;
+    let mut trust_store = TrustStoreMode::default();
+    let mut event_sink: Option<client::RequestEventSink> = None;
+
+    if let Some(extras) = extras {
+        browser = extras
+            .get_opt(&mut cx, "browser")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| parse_emulation(&v.value(&mut cx)));
+        browser_os = extras
+            .get_opt(&mut cx, "os")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| parse_emulation_os(&v.value(&mut cx)));
+        emulation_json = extras
+            .get_opt(&mut cx, "emulationJson")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| Arc::<str>::from(v.value(&mut cx)));
+        proxy = extras
+            .get_opt(&mut cx, "proxy")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| Arc::<str>::from(v.value(&mut cx)));
+        trust_store = extras
+            .get_opt(&mut cx, "trustStore")?
+            .and_then(|v: Handle<JsValue>| v.downcast::<JsString, _>(&mut cx).ok())
+            .map(|v| parse_trust_store_mode(&v.value(&mut cx)))
+            .unwrap_or_default();
+        event_sink = extras
+            .get_opt::<JsFunction, _, _>(&mut cx, "onRequestEvent")?
+            .map(|callback| {
+                let callback = Arc::new(callback.root(&mut cx));
+                let channel = settle_channel.clone();
+                Arc::new(move |event: RequestEvent| {
+                    let callback = callback.clone();
+                    channel.send(move |mut cx| {
+                        let cb = callback.to_inner(&mut cx);
+                        let this = cx.undefined();
+                        let event_obj = request_event_to_js_object(&mut cx, event)?;
+                        cb.call(&mut cx, this, vec![event_obj.upcast()])?;
+                        Ok(())
+                    });
+                }) as client::RequestEventSink
+            });
+    }
+
+    let redirect = if flags & FLAG_REDIRECT_MANUAL != 0 {
+        RedirectMode::Manual
+    } else if flags & FLAG_REDIRECT_ERROR != 0 {
+        RedirectMode::Error
+    } else {
+        RedirectMode::Follow
+    };
+
+    let session_id = if session_id.trim().is_empty() {
+        generate_session_id()
+    } else {
+        session_id
+    };
+    let transport_id = transport_id.filter(|v| !v.trim().is_empty());
+
+    let options = RequestOptions {
+        url,
+        browser,
+        browser_os,
+        emulation_json,
+        headers,
+        method: if method.is_empty() { "GET".to_string() } else { method },
+        body,
+        proxy,
+        timeout: if timeout.is_finite() && timeout >= 0.0 { timeout as u64 } else { 30000 },
+        redirect,
+        session_id,
+        ephemeral: flags & FLAG_EPHEMERAL != 0,
+        disable_default_headers: flags & FLAG_DISABLE_DEFAULT_HEADERS != 0,
+        insecure: flags & FLAG_INSECURE != 0,
+        trust_store,
+        transport_id,
+        pool_idle_timeout: None,
+        pool_max_idle_per_host: None,
+        pool_max_size: None,
+        connect_timeout: None,
+        read_timeout: None,
+        compress: flags & FLAG_NO_COMPRESS == 0,
+        capture_diagnostics: flags & FLAG_CAPTURE_DIAGNOSTICS != 0,
+        event_sink,
+    };
     let error_event_sink = options.event_sink.clone();
 
     let (deferred, promise) = cx.promise();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,6 @@
 mod client;
 mod custom_emulation;
+mod external_buffer;
 mod generated_profiles;
 mod websocket;
 
@@ -279,7 +280,7 @@ fn response_to_js_object<'a, C: Context<'a>>(
 
     // Absent fields are left absent rather than set to null; JS reads them with `??`.
     if let Some(bytes) = response.body_bytes {
-        let buffer = JsBuffer::from_slice(cx, &bytes)?;
+        let buffer = external_buffer::bytes_to_js_buffer(cx, bytes)?;
         obj.set(cx, "bodyBytes", buffer)?;
     }
 
@@ -952,7 +953,7 @@ fn read_body_chunk(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
         deferred.settle_with(&settle_channel, move |mut cx| match result {
             Ok(Some(bytes)) => {
-                let buffer = JsBuffer::from_slice(&mut cx, &bytes)?;
+                let buffer = external_buffer::bytes_to_js_buffer(&mut cx, bytes)?;
                 let value: Handle<JsValue> = buffer.upcast();
                 Ok(value)
             }
@@ -984,10 +985,7 @@ fn read_body_all(mut cx: FunctionContext) -> JsResult<JsPromise> {
         let result = native_read_body_all(handle_id).await;
 
         deferred.settle_with(&settle_channel, move |mut cx| match result {
-            Ok(bytes) => {
-                let buffer = JsBuffer::from_slice(&mut cx, &bytes)?;
-                Ok(buffer)
-            }
+            Ok(bytes) => external_buffer::bytes_to_js_buffer(&mut cx, bytes),
             Err(e) => {
                 let error_msg = format!("{:#}", e);
                 cx.throw_error(error_msg)
@@ -1702,8 +1700,22 @@ fn set_cookies(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 }
 
 // Module initialization
+/// Runtime hints from JS. `externalBuffers: false` makes every body a copied buffer.
+fn configure_runtime(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let options = cx.argument::<JsObject>(0)?;
+    let external = options
+        .get_opt::<JsBoolean, _, _>(&mut cx, "externalBuffers")?
+        .map(|value| value.value(&mut cx))
+        .unwrap_or(true);
+    external_buffer::set_enabled(external);
+    Ok(cx.undefined())
+}
+
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    external_buffer::init(&mut cx);
+
+    cx.export_function("configureRuntime", configure_runtime)?;
     cx.export_function("request", request)?;
     cx.export_function("cancelRequest", cancel_request)?;
     cx.export_function("readBodyChunk", read_body_chunk)?;

--- a/src/test/helpers/local-test-server.ts
+++ b/src/test/helpers/local-test-server.ts
@@ -349,6 +349,20 @@ export async function startLocalTestServer(): Promise<LocalTestServer> {
       return;
     }
 
+    if (path === "/chunked/many") {
+      // Many small chunked frames written back to back with no delay, so several of
+      // them are typically in flight or buffered by the time the client reads.
+      const count = Math.max(1, Math.min(Number(url.searchParams.get("n") ?? "64"), 4096));
+      const size = Math.max(1, Math.min(Number(url.searchParams.get("size") ?? "1024"), 65536));
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/octet-stream");
+      for (let i = 0; i < count; i += 1) {
+        res.write(Buffer.alloc(size, i & 0xff));
+      }
+      res.end();
+      return;
+    }
+
     if (path === "/stream/slow") {
       // First chunk immediately, second after a pause, so the body cannot be
       // complete when the response is handed to JS and must be streamed.

--- a/src/test/helpers/local-test-server.ts
+++ b/src/test/helpers/local-test-server.ts
@@ -337,6 +337,30 @@ export async function startLocalTestServer(): Promise<LocalTestServer> {
       return;
     }
 
+    if (path === "/stream/slow") {
+      // First chunk immediately, second after a pause long enough to outlast the
+      // native inline window, so the body must be delivered as a stream.
+      const gapMs = Math.max(1, Math.min(Number(url.searchParams.get("gap") ?? "200"), 5000));
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/octet-stream");
+      res.write(Buffer.alloc(256, 1));
+      await delay(gapMs);
+      res.write(Buffer.alloc(256, 2));
+      res.end();
+      return;
+    }
+
+    if (path === "/sse") {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/event-stream");
+      res.setHeader("Cache-Control", "no-cache");
+      res.write("data: first\n\n");
+      await delay(200);
+      res.write("data: second\n\n");
+      res.end();
+      return;
+    }
+
     if (path === "/cookies") {
       return json(res, { cookies: parseCookies(req.headers.cookie) });
     }

--- a/src/test/helpers/local-test-server.ts
+++ b/src/test/helpers/local-test-server.ts
@@ -337,9 +337,21 @@ export async function startLocalTestServer(): Promise<LocalTestServer> {
       return;
     }
 
+    if (path === "/chunked") {
+      // Chunked transfer with no Content-Length. end(data) corks the socket so the
+      // data chunk and the terminating chunk leave in a single flush, the way a
+      // server that flushes properly (or any HTTP/2 END_STREAM frame) behaves.
+      // write(data) followed by end() would send the terminator separately.
+      const size = Math.max(1, Math.min(Number(url.searchParams.get("size") ?? "512"), 65536));
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/octet-stream");
+      res.end(Buffer.alloc(size, 7));
+      return;
+    }
+
     if (path === "/stream/slow") {
-      // First chunk immediately, second after a pause long enough to outlast the
-      // native inline window, so the body must be delivered as a stream.
+      // First chunk immediately, second after a pause, so the body cannot be
+      // complete when the response is handed to JS and must be streamed.
       const gapMs = Math.max(1, Math.min(Number(url.searchParams.get("gap") ?? "200"), 5000));
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/octet-stream");

--- a/src/test/http/body-abandon.spec.ts
+++ b/src/test/http/body-abandon.spec.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert";
+import { createServer } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { describe, test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { createSession } from "../../wreq-js.js";
+
+// Cancelling or abandoning a response body with data still unread leaves the HTTP/1.1
+// connection in the middle of a message. The native layer drains a small remainder
+// (up to 128 KiB, undici's dump() cap) so the connection can go back to the pool, and
+// drops the connection when more than that is left.
+async function withSlowServer(
+  chunks: number[],
+  gapMs: number,
+  run: (baseUrl: string, accepted: () => number) => Promise<void>,
+  announceLength = false,
+): Promise<void> {
+  const sockets = new Set<Socket>();
+  let accepted = 0;
+  const server = createServer(async (_req, res) => {
+    res.setHeader("Content-Type", "application/octet-stream");
+    if (announceLength) {
+      res.setHeader("Content-Length", String(chunks.reduce((sum, size) => sum + size, 0)));
+    }
+    for (let i = 0; i < chunks.length; i += 1) {
+      res.write(Buffer.alloc(chunks[i] as number, i + 1));
+      await delay(gapMs);
+    }
+    res.end();
+  });
+  server.on("connection", (socket: Socket) => {
+    accepted += 1;
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => undefined);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    await run(`http://127.0.0.1:${port}`, () => accepted);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe("abandoned response bodies", () => {
+  test("a small unread remainder is drained and the connection is reused", async () => {
+    // 4 x 4 KiB with 20 ms gaps: at hand-off only the first chunk is in, 12 KiB remain.
+    await withSlowServer([4096, 4096, 4096, 4096], 20, async (baseUrl, accepted) => {
+      const session = await createSession();
+      try {
+        for (let i = 0; i < 6; i += 1) {
+          const response = await session.fetch(`${baseUrl}/slow`, { timeout: 10_000 });
+          assert.strictEqual(response.status, 200);
+          assert.strictEqual(response.contentLength, null, "the body must be on the streaming path");
+          await response.body?.cancel();
+          // Give the drain time to finish before the next request wants the connection.
+          await delay(120);
+        }
+        assert.strictEqual(accepted(), 1, "every request should have reused one connection");
+      } finally {
+        await session.close();
+      }
+    });
+  });
+
+  test("a large unread remainder drops the connection instead", async () => {
+    // Chunked (no Content-Length, so the streaming path) with ~1 MiB still to come after
+    // the first 4 KiB. That is far above the drain cap, so the body is dropped and hyper
+    // closes the connection rather than draining it.
+    const chunks = [4096, ...Array.from({ length: 8 }, () => 131072)];
+    await withSlowServer(chunks, 20, async (baseUrl, accepted) => {
+      const session = await createSession();
+      try {
+        for (let i = 0; i < 3; i += 1) {
+          const response = await session.fetch(`${baseUrl}/slow`, { timeout: 10_000 });
+          assert.strictEqual(response.status, 200);
+          assert.strictEqual(response.contentLength, null, "the body must be on the streaming path");
+          await response.body?.cancel();
+          await delay(250);
+        }
+        assert.strictEqual(accepted(), 3, "each request should have needed a fresh connection");
+      } finally {
+        await session.close();
+      }
+    });
+  });
+});

--- a/src/test/http/coverage.spec.ts
+++ b/src/test/http/coverage.spec.ts
@@ -456,11 +456,10 @@ describe("Session validation", () => {
 describe("Response helpers", () => {
   const makePayload = (overrides?: Partial<Record<string, unknown>>) => ({
     status: 200,
-    headers: [["X-Test", "alpha"]],
+    headers: ["X-Test", "alpha"],
     bodyHandle: null,
     bodyBytes: null,
     contentLength: null,
-    cookies: [],
     url: "http://example.com/final",
     ...overrides,
   });
@@ -482,11 +481,8 @@ describe("Response helpers", () => {
     const response = new Response(
       makePayload({
         status: 200,
-        headers: [["X-Test", "alpha"]],
-        cookies: [
-          ["session", "one"],
-          ["session", "two"],
-        ],
+        headers: ["X-Test", "alpha"],
+        cookies: ["session", "one", "session", "two"],
       }) as never,
       "http://example.com/final",
     );
@@ -539,7 +535,7 @@ describe("Response helpers", () => {
   test("supports blob and formData helpers", async () => {
     const blobResponse = new Response(
       makePayload({
-        headers: [["Content-Type", "text/plain"]],
+        headers: ["Content-Type", "text/plain"],
         bodyBytes: Buffer.from("blob-text"),
       }) as never,
       "http://example.com/final",
@@ -550,7 +546,7 @@ describe("Response helpers", () => {
 
     const formResponse = new Response(
       makePayload({
-        headers: [["Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"]],
+        headers: ["Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"],
         bodyBytes: Buffer.from("alpha=one&beta=two"),
       }) as never,
       "http://example.com/final",

--- a/src/test/http/inline-body.spec.ts
+++ b/src/test/http/inline-body.spec.ts
@@ -4,9 +4,11 @@ import { fetch as wreqFetch } from "../../wreq-js.js";
 import { httpUrl, isLocalHttpBase } from "../helpers/http.js";
 
 // Bodies without a Content-Length (chunked transfer, or anything compressed, since
-// decoding drops the header) are buffered natively when they arrive quickly, so they
-// take the same inline path as small known-length bodies. `contentLength` is only
-// non-null when that happened, which makes the path observable from JS.
+// decoding drops the header) are inlined natively when they have already fully
+// arrived by the time the response is handed to JS, so they take the same inline
+// path as small known-length bodies. Nothing waits on the network for this.
+// `contentLength` is only non-null when that happened, which makes the path
+// observable from JS.
 describe("inline body buffering for unknown-length responses", () => {
   test("small compressed responses are inlined with their decoded length", { skip: !isLocalHttpBase }, async () => {
     const response = await wreqFetch(httpUrl("/gzip"), { browser: "chrome_142", timeout: 10_000 });
@@ -16,8 +18,8 @@ describe("inline body buffering for unknown-length responses", () => {
     assert.strictEqual(response.contentLength, JSON.stringify(body).length, "decoded length should be reported");
   });
 
-  test("a chunked body that completes quickly is inlined", { skip: !isLocalHttpBase }, async () => {
-    const response = await wreqFetch(httpUrl("/stream/chunks?n=1&size=512"), {
+  test("a chunked body that has fully arrived is inlined", { skip: !isLocalHttpBase }, async () => {
+    const response = await wreqFetch(httpUrl("/chunked?size=512"), {
       browser: "chrome_142",
       timeout: 10_000,
     });
@@ -58,7 +60,7 @@ describe("inline body buffering for unknown-length responses", () => {
     assert.strictEqual(last?.[last.byteLength - 1], 2, "the live tail follows the prefix");
   });
 
-  test("text/event-stream responses are never held back", { skip: !isLocalHttpBase }, async () => {
+  test("text/event-stream responses deliver their first event immediately", { skip: !isLocalHttpBase }, async () => {
     const started = performance.now();
     const response = await wreqFetch(httpUrl("/sse"), { browser: "chrome_142", timeout: 10_000 });
 

--- a/src/test/http/inline-body.spec.ts
+++ b/src/test/http/inline-body.spec.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { fetch as wreqFetch } from "../../wreq-js.js";
+import { httpUrl, isLocalHttpBase } from "../helpers/http.js";
+
+// Bodies without a Content-Length (chunked transfer, or anything compressed, since
+// decoding drops the header) are buffered natively when they arrive quickly, so they
+// take the same inline path as small known-length bodies. `contentLength` is only
+// non-null when that happened, which makes the path observable from JS.
+describe("inline body buffering for unknown-length responses", () => {
+  test("small compressed responses are inlined with their decoded length", { skip: !isLocalHttpBase }, async () => {
+    const response = await wreqFetch(httpUrl("/gzip"), { browser: "chrome_142", timeout: 10_000 });
+    const body = await response.json<{ message: string; gzipped: boolean }>();
+
+    assert.deepStrictEqual(body, { message: "compressed", gzipped: true });
+    assert.strictEqual(response.contentLength, JSON.stringify(body).length, "decoded length should be reported");
+  });
+
+  test("a chunked body that completes quickly is inlined", { skip: !isLocalHttpBase }, async () => {
+    const response = await wreqFetch(httpUrl("/stream/chunks?n=1&size=512"), {
+      browser: "chrome_142",
+      timeout: 10_000,
+    });
+    const bytes = await response.bytes();
+
+    assert.strictEqual(bytes.byteLength, 512);
+    assert.strictEqual(response.contentLength, 512);
+  });
+
+  test("a chunked body that stalls is still streamed, with the early bytes first", {
+    skip: !isLocalHttpBase,
+  }, async () => {
+    const started = performance.now();
+    const response = await wreqFetch(httpUrl("/stream/slow?gap=300"), {
+      browser: "chrome_142",
+      timeout: 10_000,
+    });
+
+    assert.strictEqual(response.contentLength, null, "a stalled body must not be inlined");
+    assert.ok(performance.now() - started < 250, "headers must not wait for the stalled chunk");
+
+    const reader = response.body?.getReader();
+    assert.ok(reader);
+    const first = await reader.read();
+    assert.strictEqual(first.done, false);
+    assert.ok(performance.now() - started < 250, "the first chunk must arrive before the stall ends");
+    assert.strictEqual(first.value?.[0], 1, "the buffered prefix is replayed first");
+
+    let total = first.value?.byteLength ?? 0;
+    let last = first.value;
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value?.byteLength ?? 0;
+      last = next.value;
+    }
+    assert.strictEqual(total, 512);
+    assert.strictEqual(last?.[last.byteLength - 1], 2, "the live tail follows the prefix");
+  });
+
+  test("text/event-stream responses are never held back", { skip: !isLocalHttpBase }, async () => {
+    const started = performance.now();
+    const response = await wreqFetch(httpUrl("/sse"), { browser: "chrome_142", timeout: 10_000 });
+
+    assert.strictEqual(response.contentLength, null);
+    const reader = response.body?.getReader();
+    assert.ok(reader);
+    const first = await reader.read();
+    assert.strictEqual(first.done, false);
+    assert.ok(performance.now() - started < 150, "the first event must not wait for the second");
+    assert.ok(new TextDecoder().decode(first.value).startsWith("data: first"));
+    await reader.cancel();
+  });
+});

--- a/src/test/http/inline-body.spec.ts
+++ b/src/test/http/inline-body.spec.ts
@@ -73,4 +73,32 @@ describe("inline body buffering for unknown-length responses", () => {
     assert.ok(new TextDecoder().decode(first.value).startsWith("data: first"));
     await reader.cancel();
   });
+
+  test("streaming a body of many small frames preserves bytes and order", { skip: !isLocalHttpBase }, async () => {
+    const count = 512;
+    const size = 1024;
+    const response = await wreqFetch(httpUrl(`/chunked/many?n=${count}&size=${size}`), {
+      browser: "chrome_142",
+      timeout: 10_000,
+    });
+
+    const reads: number[] = [];
+    let offset = 0;
+    for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
+      reads.push(chunk.byteLength);
+      for (let i = 0; i < chunk.byteLength; i += 1) {
+        const expected = Math.floor((offset + i) / size) & 0xff;
+        if (chunk[i] !== expected) {
+          assert.fail(`byte ${offset + i} was ${chunk[i]}, expected ${expected}`);
+        }
+      }
+      offset += chunk.byteLength;
+    }
+
+    assert.strictEqual(offset, count * size, "every byte must arrive exactly once");
+    // Frames that were already delivered natively are merged into one read, so the
+    // client sees far fewer reads than the server wrote frames. Not asserted as an
+    // exact count: it depends on timing, only on it being a real reduction.
+    assert.ok(reads.length < count, `expected coalesced reads, got ${reads.length} for ${count} frames`);
+  });
 });

--- a/src/test/http/large-body.spec.ts
+++ b/src/test/http/large-body.spec.ts
@@ -3,7 +3,7 @@ import { describe, test } from "node:test";
 import { fetch as wreqFetch } from "../../wreq-js.js";
 import { httpUrl, isLocalHttpBase } from "../helpers/http.js";
 
-// Bodies of 64 KiB and more are handed to JS as external buffers that own the native
+// Bodies of 256 KiB and more are handed to JS as external buffers that own the native
 // allocation (or copied, on runtimes that refuse external buffers). Either way the
 // bytes, the zero-copy arrayBuffer() view, and the streamed variant must be intact.
 describe("large response bodies", () => {

--- a/src/test/http/large-body.spec.ts
+++ b/src/test/http/large-body.spec.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { fetch as wreqFetch } from "../../wreq-js.js";
+import { httpUrl, isLocalHttpBase } from "../helpers/http.js";
+
+// Bodies of 64 KiB and more are handed to JS as external buffers that own the native
+// allocation (or copied, on runtimes that refuse external buffers). Either way the
+// bytes, the zero-copy arrayBuffer() view, and the streamed variant must be intact.
+describe("large response bodies", () => {
+  test("a 64 KiB inline body round-trips and arrayBuffer() covers the whole buffer", {
+    skip: !isLocalHttpBase,
+  }, async () => {
+    const size = 65536;
+    const response = await wreqFetch(httpUrl(`/chunked?size=${size}`), { browser: "chrome_142", timeout: 10_000 });
+    const buffer = await response.arrayBuffer();
+
+    assert.strictEqual(buffer.byteLength, size);
+    const view = new Uint8Array(buffer);
+    assert.strictEqual(view[0], 7);
+    assert.strictEqual(view[size - 1], 7);
+    assert.ok(
+      view.every((byte) => byte === 7),
+      "every byte must be the server's fill value",
+    );
+  });
+
+  test("text() decodes a large body handed over without a copy", { skip: !isLocalHttpBase }, async () => {
+    const response = await wreqFetch(httpUrl("/chunked?size=65536"), { browser: "chrome_142", timeout: 10_000 });
+    const text = await response.text();
+    assert.strictEqual(text.length, 65536);
+    assert.strictEqual(text.charCodeAt(0), 7);
+  });
+
+  test("a streamed body above the threshold arrives intact", { skip: !isLocalHttpBase }, async () => {
+    const count = 512;
+    const size = 1024;
+    const response = await wreqFetch(httpUrl(`/chunked/many?n=${count}&size=${size}`), {
+      browser: "chrome_142",
+      timeout: 10_000,
+    });
+    const bytes = await response.bytes();
+    assert.strictEqual(bytes.byteLength, count * size);
+    for (let i = 0; i < bytes.byteLength; i += 4099) {
+      assert.strictEqual(bytes[i], Math.floor(i / size) & 0xff, `byte ${i}`);
+    }
+  });
+
+  test("many large bodies can be fetched back to back", { skip: !isLocalHttpBase }, async () => {
+    // Exercises finalizers and the external-memory accounting under some churn.
+    for (let i = 0; i < 64; i += 1) {
+      const response = await wreqFetch(httpUrl("/chunked?size=65536"), { browser: "chrome_142", timeout: 10_000 });
+      const bytes = await response.bytes();
+      assert.strictEqual(bytes.byteLength, 65536);
+    }
+  });
+});

--- a/src/test/http/requests.spec.ts
+++ b/src/test/http/requests.spec.ts
@@ -132,35 +132,47 @@ describe("HTTP requests", () => {
     assert.ok(response.bodyUsed, "arrayBuffer() should mark the body as used");
   });
 
-  test("streams response bodies via ReadableStream", { skip: !isLocalHttpBase }, async () => {
-    const response = await wreqFetch(httpUrl("/stream/chunks?n=4&size=64"), {
-      browser: "chrome_142",
-      timeout: 10_000,
-    });
+  for (const { name, route, chunkCount, chunkSize } of [
+    { name: "paced", route: "/stream/chunks", chunkCount: 4, chunkSize: 64 },
+    { name: "buffered", route: "/chunked/many", chunkCount: 4, chunkSize: 64 },
+    { name: "large", route: "/chunked/many", chunkCount: 512, chunkSize: 8192 },
+  ]) {
+    test(`streams ${name} response bodies via ReadableStream`, { skip: !isLocalHttpBase }, async () => {
+      const response = await wreqFetch(httpUrl(`${route}?n=${chunkCount}&size=${chunkSize}`), {
+        browser: "chrome_142",
+        timeout: 10_000,
+      });
 
-    assert.ok(response.body && typeof response.body.getReader === "function", "body should be a ReadableStream");
-    assert.strictEqual(response.bodyUsed, false, "bodyUsed should remain false before consumption");
+      assert.ok(response.body && typeof response.body.getReader === "function", "body should be a ReadableStream");
+      assert.strictEqual(response.bodyUsed, false, "bodyUsed should remain false before consumption");
 
-    const reader = response.body?.getReader();
-    let chunkCount = 0;
-    let totalBytes = 0;
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          assert.ok(value, "chunk should have data");
+          chunks.push(value);
+        }
+      } finally {
+        reader.releaseLock();
       }
 
-      chunkCount += 1;
-      totalBytes += value?.byteLength ?? 0;
-      assert.ok(value, "chunk should have data");
-      assert.strictEqual(value?.[0], chunkCount - 1, "chunk data should preserve order");
-    }
-
-    assert.strictEqual(chunkCount, 4, "should receive all chunks");
-    assert.strictEqual(totalBytes, 4 * 64, "should receive expected byte count");
-    assert.ok(response.bodyUsed, "stream consumption should mark the body as used");
-  });
+      // Stream reads may split or combine server writes. Check every byte in order,
+      // independently of read boundaries, for both inline and native streamed bodies.
+      const actual = Buffer.concat(chunks);
+      const expected = Buffer.alloc(chunkCount * chunkSize);
+      for (let i = 0; i < chunkCount; i += 1) {
+        expected.fill(i & 0xff, i * chunkSize, (i + 1) * chunkSize);
+      }
+      assert.strictEqual(actual.length, expected.length, "should receive expected byte count");
+      assert.deepStrictEqual(actual, expected, "stream should preserve every byte in order");
+      assert.ok(response.bodyUsed, "stream consumption should mark the body as used");
+    });
+  }
 
   test("cancelling a response stream marks body as used and prevents re-read", { skip: !isLocalHttpBase }, async () => {
     const response = await wreqFetch(httpUrl("/stream/chunks?n=8&size=128"), {

--- a/src/test/http/requests.spec.ts
+++ b/src/test/http/requests.spec.ts
@@ -212,7 +212,8 @@ describe("HTTP requests", () => {
   test("clones a native body after body access without consuming the original", {
     skip: !isLocalHttpBase,
   }, async () => {
-    const response = await wreqFetch(httpUrl("/stream/chunks?n=4&size=128"), {
+    // Exceed the inline limit even if the entire response arrives before fetch resolves.
+    const response = await wreqFetch(httpUrl("/chunked/many?n=512&size=8192"), {
       browser: "chrome_142",
       timeout: 10_000,
     });
@@ -222,7 +223,7 @@ describe("HTTP requests", () => {
     assert.strictEqual(response.bodyUsed, false);
     const originalBytes = await response.bytes();
     assert.deepStrictEqual(originalBytes, clonedBytes);
-    assert.strictEqual(originalBytes.byteLength, 512);
+    assert.strictEqual(originalBytes.byteLength, 512 * 8192);
     assert.strictEqual(response.bodyUsed, true);
   });
 

--- a/src/test/http/requests.spec.ts
+++ b/src/test/http/requests.spec.ts
@@ -209,6 +209,23 @@ describe("HTTP requests", () => {
     await assert.rejects(async () => response.text(), /already\s+.*used/i);
   });
 
+  test("clones a native body after body access without consuming the original", {
+    skip: !isLocalHttpBase,
+  }, async () => {
+    const response = await wreqFetch(httpUrl("/stream/chunks?n=4&size=128"), {
+      browser: "chrome_142",
+      timeout: 10_000,
+    });
+    assert.ok(response.body);
+    const clone = response.clone();
+    const clonedBytes = await clone.bytes();
+    assert.strictEqual(response.bodyUsed, false);
+    const originalBytes = await response.bytes();
+    assert.deepStrictEqual(originalBytes, clonedBytes);
+    assert.strictEqual(originalBytes.byteLength, 512);
+    assert.strictEqual(response.bodyUsed, true);
+  });
+
   test("follows redirects by default", { skip: !isLocalHttpBase }, async () => {
     const response = await wreqFetch(httpUrl("/redirect"), {
       browser: "chrome_142",

--- a/src/test/http/session-id-pooling.spec.ts
+++ b/src/test/http/session-id-pooling.spec.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert";
+import { createServer } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { describe, test } from "node:test";
+import { fetch as wreqFetch } from "../../wreq-js.js";
+
+async function withCountingServer(run: (baseUrl: string, connections: () => number) => Promise<void>): Promise<void> {
+  const sockets = new Set<Socket>();
+  let accepted = 0;
+  const server = createServer((_req, res) => {
+    res.setHeader("Content-Type", "text/plain");
+    res.end("ok");
+  });
+  server.on("connection", (socket: Socket) => {
+    accepted += 1;
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => undefined);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    await run(`http://127.0.0.1:${port}`, () => accepted);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe("sessionId request pooling", () => {
+  test("repeated fetches with the same sessionId reuse connections", async () => {
+    await withCountingServer(async (baseUrl, connections) => {
+      const sessionId = `pooling-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const requests = 8;
+
+      for (let i = 0; i < requests; i += 1) {
+        const response = await wreqFetch(`${baseUrl}/ping`, { sessionId, cookieMode: "session", timeout: 10_000 });
+        assert.strictEqual(await response.text(), "ok");
+      }
+
+      // Every request used to build a fresh client (and trust store), so each one
+      // opened a new TCP connection. A cached per-session client reuses them.
+      assert.ok(
+        connections() < requests,
+        `expected connection reuse, but ${connections()} connections were opened for ${requests} requests`,
+      );
+    });
+  });
+
+  test("different sessionIds do not share connections", async () => {
+    await withCountingServer(async (baseUrl, connections) => {
+      const a = `pooling-a-${Date.now()}`;
+      const b = `pooling-b-${Date.now()}`;
+
+      await (await wreqFetch(`${baseUrl}/a`, { sessionId: a, cookieMode: "session", timeout: 10_000 })).text();
+      await (await wreqFetch(`${baseUrl}/b`, { sessionId: b, cookieMode: "session", timeout: 10_000 })).text();
+
+      assert.strictEqual(connections(), 2, "each session id should get its own pooled client");
+    });
+  });
+});

--- a/src/test/http/session-lifetime.spec.ts
+++ b/src/test/http/session-lifetime.spec.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { setImmediate as nextTick } from "node:timers/promises";
+import { createSession, fetch as wreqFetch } from "../../wreq-js.js";
+import { httpUrl, isLocalHttpBase } from "../helpers/http.js";
+
+const forceGc = (globalThis as { gc?: () => void }).gc;
+
+// The string-id request path reads the same native jar as the Session object, without
+// keeping a JS reference to it, so it can observe whether the jar still exists.
+async function cookiesViaStringId(sessionId: string): Promise<Record<string, string>> {
+  const response = await wreqFetch(httpUrl("/cookies"), { sessionId, cookieMode: "session", timeout: 10_000 });
+  const body = await response.json<{ cookies: Record<string, string> }>();
+  return body.cookies;
+}
+
+describe("session lifetime", () => {
+  test("a session keeps its cookie jar for as long as it is open", { skip: !isLocalHttpBase }, async () => {
+    const session = await createSession({ sessionId: `keep-${Date.now()}-${Math.random().toString(16).slice(2)}` });
+    try {
+      session.setCookie("token", "abc123", httpUrl("/cookies"));
+      assert.deepStrictEqual(await cookiesViaStringId(session.id), { token: "abc123" });
+      assert.deepStrictEqual(session.getCookies(httpUrl("/cookies")), { token: "abc123" });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("close() releases the native jar", { skip: !isLocalHttpBase }, async () => {
+    const session = await createSession({ sessionId: `close-${Date.now()}-${Math.random().toString(16).slice(2)}` });
+    session.setCookie("token", "abc123", httpUrl("/cookies"));
+    await session.close();
+
+    assert.deepStrictEqual(await cookiesViaStringId(session.id), {}, "a closed session's cookies must be gone");
+  });
+
+  test("an unreferenced Session releases its native jar when garbage collected", {
+    skip: !isLocalHttpBase || typeof forceGc !== "function",
+  }, async () => {
+    const sessionId = `gc-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+    // Scope the Session so nothing holds it once this function returns.
+    await (async () => {
+      const session = await createSession({ sessionId });
+      session.setCookie("token", "abc123", httpUrl("/cookies"));
+    })();
+
+    assert.deepStrictEqual(await cookiesViaStringId(sessionId), { token: "abc123" });
+
+    let released = false;
+    for (let attempt = 0; attempt < 50 && !released; attempt += 1) {
+      forceGc?.();
+      await nextTick();
+      await nextTick();
+      released = Object.keys(await cookiesViaStringId(sessionId)).length === 0;
+    }
+
+    assert.ok(released, "the finalizer should have dropped the jar after the Session was collected");
+  });
+});

--- a/src/test/http/tls-resumption.spec.ts
+++ b/src/test/http/tls-resumption.spec.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { once } from "node:events";
 import { readFileSync } from "node:fs";
+import { createSecureServer, type ServerHttp2Session } from "node:http2";
 import { createServer as createHttpsServer } from "node:https";
 import { dirname, resolve } from "node:path";
 import { describe, test } from "node:test";
@@ -56,6 +57,55 @@ describe("TLS session resumption", () => {
       reusedSessions.every((reused) => reused === false),
       `Expected no TLS session resumption, saw: ${JSON.stringify(reusedSessions)}`,
     );
+  });
+
+  test("parallel ephemeral HTTP/2 requests keep connections, TLS, cookies, and authorization separate", async () => {
+    const server = createSecureServer({
+      key: readFileSync(resolve(CERTS_DIR, "self-signed.key")),
+      cert: readFileSync(resolve(CERTS_DIR, "self-signed.crt")),
+    });
+    const sessions = new Set<ServerHttp2Session>();
+    const resumed: boolean[] = [];
+    server.on("session", (session) => sessions.add(session));
+    server.on("secureConnection", (socket) => resumed.push(socket.isSessionReused()));
+    server.on("stream", (stream, headers) => {
+      stream.respond({ ":status": 200, "set-cookie": "identity=previous-request; Path=/" });
+      stream.end(JSON.stringify({ cookie: headers.cookie ?? null, authorization: headers.authorization ?? null }));
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+
+    try {
+      // Two bursts exercise both a cold configuration and its cached client.
+      for (let burst = 0; burst < 2; burst += 1) {
+        await Promise.all(
+          Array.from({ length: 16 }, async (_, index) => {
+            const authorization = burst === 0 && index % 2 === 0 ? `Bearer request-${index}` : null;
+            const response = await wreqFetch(`https://127.0.0.1:${address.port}/`, {
+              browser: "chrome_142",
+              os: "linux",
+              insecure: true,
+              timeout: 10_000,
+              ...(authorization ? { headers: { authorization } } : {}),
+            });
+            assert.deepStrictEqual(await response.json(), { cookie: null, authorization });
+          }),
+        );
+      }
+      assert.strictEqual(sessions.size, 32, "every request needs its own HTTP/2 connection");
+      assert.strictEqual(resumed.length, 32);
+      assert.ok(
+        resumed.every((value) => value === false),
+        "TLS sessions must not resume across requests",
+      );
+    } finally {
+      for (const session of sessions) session.destroy();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => (error ? rejectClose(error) : resolveClose()));
+      });
+    }
   });
 
   test("explicit transports still allow TLS session resumption when reconnecting", async () => {

--- a/src/test/http/tls-resumption.spec.ts
+++ b/src/test/http/tls-resumption.spec.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import { createServer as createHttpsServer } from "node:https";
+import { dirname, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { createTransport, fetch as wreqFetch } from "../../wreq-js.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CERTS_DIR = resolve(__dirname, "../helpers/certs");
+
+describe("TLS session resumption", () => {
+  test("default fetch does not resume TLS sessions across cached ephemeral clients", async () => {
+    const key = readFileSync(resolve(CERTS_DIR, "self-signed.key"));
+    const cert = readFileSync(resolve(CERTS_DIR, "self-signed.crt"));
+    const reusedSessions: boolean[] = [];
+
+    const server = createHttpsServer({ key, cert }, (_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    server.on("secureConnection", (socket) => {
+      reusedSessions.push(socket.isSessionReused());
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to determine HTTPS test server address");
+    }
+
+    try {
+      const url = `https://127.0.0.1:${address.port}/json`;
+
+      for (let index = 0; index < 6; index += 1) {
+        const response = await wreqFetch(url, {
+          browser: "chrome_142",
+          timeout: 10_000,
+          insecure: true,
+        });
+
+        await response.arrayBuffer();
+      }
+    } finally {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => (error ? rejectClose(error) : resolveClose()));
+      });
+    }
+
+    assert.strictEqual(reusedSessions.length, 6, "Each request should establish a fresh TLS connection");
+    assert.ok(
+      reusedSessions.every((reused) => reused === false),
+      `Expected no TLS session resumption, saw: ${JSON.stringify(reusedSessions)}`,
+    );
+  });
+
+  test("explicit transports still allow TLS session resumption when reconnecting", async () => {
+    const key = readFileSync(resolve(CERTS_DIR, "self-signed.key"));
+    const cert = readFileSync(resolve(CERTS_DIR, "self-signed.crt"));
+    const reusedSessions: boolean[] = [];
+
+    const server = createHttpsServer({ key, cert }, (_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    server.on("secureConnection", (socket) => {
+      reusedSessions.push(socket.isSessionReused());
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to determine HTTPS test server address");
+    }
+
+    const transport = await createTransport({
+      browser: "chrome_142",
+      insecure: true,
+      poolMaxIdlePerHost: 0,
+    });
+
+    try {
+      const url = `https://127.0.0.1:${address.port}/json`;
+
+      for (let index = 0; index < 6; index += 1) {
+        const response = await wreqFetch(url, {
+          transport,
+          timeout: 10_000,
+        });
+
+        await response.arrayBuffer();
+      }
+    } finally {
+      await transport.close();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => (error ? rejectClose(error) : resolveClose()));
+      });
+    }
+
+    assert.strictEqual(reusedSessions.length, 6, "Each request should establish a fresh TLS connection");
+    assert.ok(
+      reusedSessions.some((reused) => reused),
+      `Expected explicit transports to retain TLS resumption, saw: ${JSON.stringify(reusedSessions)}`,
+    );
+  });
+});

--- a/src/test/http/transport-lifetime.spec.ts
+++ b/src/test/http/transport-lifetime.spec.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert";
+import { createServer } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { describe, test } from "node:test";
+import { setImmediate as nextTick, setTimeout as delay } from "node:timers/promises";
+import { createTransport, fetch as wreqFetch } from "../../wreq-js.js";
+
+const forceGc = (globalThis as { gc?: () => void }).gc;
+
+// A transport's pooled keep-alive connection stays open on the server for as long as
+// the native client exists, so the server's open-socket count shows whether the
+// native transport was released.
+async function withCountingServer(run: (baseUrl: string, openSockets: () => number) => Promise<void>): Promise<void> {
+  const sockets = new Set<Socket>();
+  const server = createServer((_req, res) => {
+    res.setHeader("Content-Type", "text/plain");
+    res.end("ok");
+  });
+  server.on("connection", (socket: Socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => undefined);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    await run(`http://127.0.0.1:${port}`, () => sockets.size);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+async function settled(openSockets: () => number, expected: number): Promise<boolean> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (openSockets() === expected) return true;
+    await delay(10);
+  }
+  return openSockets() === expected;
+}
+
+describe("transport lifetime", () => {
+  test("close() drops the pooled connection", async () => {
+    await withCountingServer(async (baseUrl, openSockets) => {
+      const transport = await createTransport();
+      await (await wreqFetch(`${baseUrl}/ping`, { transport, timeout: 10_000 })).text();
+      assert.ok(await settled(openSockets, 1), "one keep-alive connection should be open");
+
+      await transport.close();
+      assert.ok(await settled(openSockets, 0), "closing the transport should close its connection");
+    });
+  });
+
+  test("an unreferenced Transport releases its native client when garbage collected", {
+    skip: typeof forceGc !== "function",
+  }, async () => {
+    await withCountingServer(async (baseUrl, openSockets) => {
+      // Scope the Transport so nothing holds it once this function returns.
+      await (async () => {
+        const transport = await createTransport();
+        await (await wreqFetch(`${baseUrl}/ping`, { transport, timeout: 10_000 })).text();
+      })();
+      assert.ok(await settled(openSockets, 1), "the pooled connection should still be open");
+
+      let released = false;
+      for (let attempt = 0; attempt < 50 && !released; attempt += 1) {
+        forceGc?.();
+        await nextTick();
+        await nextTick();
+        await delay(10);
+        released = openSockets() === 0;
+      }
+
+      assert.ok(released, "the finalizer should have dropped the transport and its connection");
+    });
+  });
+});

--- a/src/test/run-with-local-server.ts
+++ b/src/test/run-with-local-server.ts
@@ -64,7 +64,8 @@ async function main() {
   env.SSL_CERT_FILE = resolve(testDir, "helpers", "certs", "default-paths-root.crt");
   env.SSL_CERT_DIR = mkdtempSync(resolve(tmpdir(), "wreq-js-empty-cert-dir-"));
 
-  const nodeArgs = ["--import", "tsx", "--test", ...defaultTestFiles, ...normalizedExtraArgs];
+  // --expose-gc lets lifecycle specs force a collection and observe finalizers.
+  const nodeArgs = ["--import", "tsx", "--expose-gc", "--test", ...defaultTestFiles, ...normalizedExtraArgs];
   const testProcess = spawn(process.execPath, nodeArgs, {
     stdio: "inherit",
     env,

--- a/src/types.ts
+++ b/src/types.ts
@@ -825,32 +825,33 @@ export interface NativeResponse {
   status: number;
 
   /**
-   * Response headers as [name, value] tuples.
-   * Header names are normalized to lowercase.
+   * Response headers as a flat [name, value, name, value, ...] array, the same
+   * shape as Node's `IncomingMessage.rawHeaders`. Header names are lowercase.
    */
-  headers: HeaderTuple[];
+  headers: string[];
 
   /**
    * Handle for streaming response body chunks from the native layer.
-   * When `null`, the response does not have a body (e.g., HEAD/204/304).
+   * Absent or `null` when the response has no body (e.g., HEAD/204/304) or the
+   * body was inlined.
    */
-  bodyHandle: number | null;
+  bodyHandle?: number | null;
 
   /**
    * Inline body buffer returned for small payloads. When present, `bodyHandle`
-   * will be `null` to avoid a second native round-trip to read the body.
+   * is absent to avoid a second native round-trip to read the body.
    */
-  bodyBytes: Buffer | null;
+  bodyBytes?: Buffer | null;
 
   /**
    * Optional Content-Length hint reported by the server after decompression.
    */
-  contentLength: number | null;
+  contentLength?: number | null;
 
   /**
-   * Cookies set by the server as [name, value] tuples.
+   * Cookies set by the server as a flat [name, value, ...] array; absent when none.
    */
-  cookies: HeaderTuple[];
+  cookies?: string[];
 
   /**
    * Final URL after following any redirects.

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -285,6 +285,36 @@ const websocketFinalizer =
 
 type NativeBodyHandle = { id: number; released: boolean };
 
+// Native session state (cookie jar, and the transport a createSession() call built for it)
+// is addressed by id and lives in the addon until dropped. Session.close() drops it
+// explicitly; this finalizer drops it for Session objects that were never closed, the same
+// way undici cancels the bodies of collected Response objects. The token doubles as the
+// held value so close() can mark the state released and unregister it.
+type SessionNativeState = { id: string; transportId?: string; ownsTransport: boolean; released: boolean };
+
+const sessionFinalizer =
+  typeof FinalizationRegistry === "function"
+    ? new FinalizationRegistry<SessionNativeState>((state: SessionNativeState) => {
+        if (state.released) {
+          return;
+        }
+
+        state.released = true;
+        try {
+          nativeBinding.dropSession(state.id);
+        } catch {
+          // Best-effort cleanup; ignore binding-level failures.
+        }
+        if (state.ownsTransport && state.transportId) {
+          try {
+            nativeBinding.dropTransport(state.transportId);
+          } catch {
+            // Best-effort cleanup; ignore binding-level failures.
+          }
+        }
+      })
+    : undefined;
+
 const bodyHandleFinalizer =
   typeof FinalizationRegistry === "function"
     ? new FinalizationRegistry<NativeBodyHandle>((handle: NativeBodyHandle) => {
@@ -1131,10 +1161,18 @@ export class Session implements SessionHandle {
   readonly id: string;
   private disposed = false;
   private readonly defaults: SessionDefaults;
+  private readonly nativeState: SessionNativeState;
 
   constructor(id: string, defaults: SessionDefaults) {
     this.id = id;
     this.defaults = defaults;
+    this.nativeState = {
+      id,
+      ...(defaults.transportId !== undefined && { transportId: defaults.transportId }),
+      ownsTransport: defaults.ownsTransport ?? false,
+      released: false,
+    };
+    sessionFinalizer?.register(this, this.nativeState, this.nativeState);
   }
 
   get closed(): boolean {
@@ -1304,6 +1342,10 @@ export class Session implements SessionHandle {
     this.disposed = true;
     const transportId = this.defaults.transportId;
     const ownsTransport = this.defaults.ownsTransport;
+
+    // Explicit close owns the cleanup from here; the finalizer must not repeat it.
+    this.nativeState.released = true;
+    sessionFinalizer?.unregister(this.nativeState);
 
     try {
       nativeBinding.dropSession(this.id);

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -1198,12 +1198,36 @@ export class Response {
   }
 }
 
+// A Transport owns a native client and its connection pool until dropTransport().
+// close() drops it explicitly; this finalizer drops it for Transport objects that were
+// never closed, the same way sessions are handled above.
+type TransportNativeState = { id: string; released: boolean };
+
+const transportFinalizer =
+  typeof FinalizationRegistry === "function"
+    ? new FinalizationRegistry<TransportNativeState>((state: TransportNativeState) => {
+        if (state.released) {
+          return;
+        }
+
+        state.released = true;
+        try {
+          nativeBinding.dropTransport(state.id);
+        } catch {
+          // Best-effort cleanup; ignore binding-level failures.
+        }
+      })
+    : undefined;
+
 export class Transport {
   readonly id: string;
   private disposed = false;
+  private readonly nativeState: TransportNativeState;
 
   constructor(id: string) {
     this.id = id;
+    this.nativeState = { id, released: false };
+    transportFinalizer?.register(this, this.nativeState, this.nativeState);
   }
 
   get closed(): boolean {
@@ -1216,6 +1240,9 @@ export class Transport {
     }
 
     this.disposed = true;
+    // Explicit close owns the cleanup from here; the finalizer must not repeat it.
+    this.nativeState.released = true;
+    transportFinalizer?.unregister(this.nativeState);
 
     try {
       nativeBinding.dropTransport(this.id);

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -181,6 +181,7 @@ let nativeBinding: {
   dropTransport: (transportId: string) => void;
   getOperatingSystems?: () => string[];
   getEmulationHeaders?: (browser: string, os: string) => HeaderTuple[];
+  configureRuntime?: (options: { externalBuffers?: boolean }) => void;
 };
 
 let cachedProfiles: BrowserProfile[] | undefined;
@@ -307,6 +308,20 @@ function loadNativeBinding() {
 }
 
 nativeBinding = loadNativeBinding();
+
+// Large bodies can arrive as external buffers that own the native allocation instead
+// of being zero-filled and copied. That is on for Node, whose collector accounts
+// external memory itself. It is off for Bun: JSC cannot see those bytes, so under
+// load it collected them late and peak memory grew 3-4x, and reporting them through
+// napi_adjust_external_memory only pushed its collection threshold further out.
+// WREQ_EXTERNAL_BUFFERS=1|0 overrides the default.
+const externalBuffersOverride = process.env.WREQ_EXTERNAL_BUFFERS;
+nativeBinding.configureRuntime?.({
+  externalBuffers:
+    externalBuffersOverride !== undefined
+      ? externalBuffersOverride !== "0"
+      : typeof (globalThis as { Bun?: unknown }).Bun === "undefined",
+});
 
 const websocketFinalizer =
   typeof FinalizationRegistry === "function"

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -127,8 +127,40 @@ interface NativeRequestOptions {
   onRequestEvent?: (event: RequestEvent) => void;
 }
 
+// Rarely used request fields travel in one optional object; the native side only probes
+// it when present, so the pooled-session hot path passes `undefined` here.
+interface NativeRequestExtras {
+  browser?: BrowserProfile;
+  os?: EmulationOS;
+  emulationJson?: string;
+  proxy?: string;
+  trustStore?: TrustStoreMode;
+  onRequestEvent?: (event: RequestEvent) => void;
+}
+
+// Bit flags for the positional native request call; must match rust/src/lib.rs.
+const FLAG_EPHEMERAL = 1;
+const FLAG_DISABLE_DEFAULT_HEADERS = 1 << 1;
+const FLAG_INSECURE = 1 << 2;
+const FLAG_NO_COMPRESS = 1 << 3;
+const FLAG_CAPTURE_DIAGNOSTICS = 1 << 4;
+const FLAG_CANCELLABLE = 1 << 5;
+const FLAG_REDIRECT_MANUAL = 1 << 6;
+const FLAG_REDIRECT_ERROR = 1 << 7;
+
 let nativeBinding: {
-  request: (options: NativeRequestOptions, requestId: number, enableCancellation?: boolean) => Promise<NativeResponse>;
+  request: (
+    url: string,
+    method: string,
+    sessionId: string,
+    requestId: number,
+    flags: number,
+    timeout: number,
+    headers: string[] | undefined,
+    body: Buffer | undefined,
+    transportId: string | undefined,
+    extras: NativeRequestExtras | undefined,
+  ) => Promise<NativeResponse>;
   cancelRequest: (requestId: number) => void;
   readBodyChunk: (handleId: number) => Promise<Buffer | null>;
   readBodyAll: (handleId: number) => Promise<Buffer>;
@@ -723,14 +755,34 @@ type ResponseType = "basic" | "cors" | "error" | "opaque" | "opaqueredirect";
 function cloneNativeResponse(payload: NativeResponse): NativeResponse {
   return {
     status: payload.status,
-    headers: payload.headers.map(([name, value]): HeaderTuple => [name, value]),
-    bodyHandle: payload.bodyHandle,
-    bodyBytes: payload.bodyBytes,
-    contentLength: payload.contentLength,
-    cookies: payload.cookies.map(([name, value]): HeaderTuple => [name, value]),
+    headers: payload.headers.slice(),
+    bodyHandle: payload.bodyHandle ?? null,
+    bodyBytes: payload.bodyBytes ?? null,
+    contentLength: payload.contentLength ?? null,
+    ...(payload.cookies !== undefined && { cookies: payload.cookies.slice() }),
     url: payload.url,
     diagnostics: payload.diagnostics ? { ...payload.diagnostics } : null,
   };
+}
+
+// The native layer reports headers the way Node's HTTP parser does, as a flat
+// [name, value, name, value, ...] array; it becomes a Headers object only on access.
+function headerTuplesFromFlat(flat: readonly string[]): HeaderTuple[] {
+  const tuples: HeaderTuple[] = [];
+  for (let i = 0; i + 1 < flat.length; i += 2) {
+    tuples.push([flat[i] as string, flat[i + 1] as string]);
+  }
+  return tuples;
+}
+
+function flattenHeaderTuples(tuples: readonly HeaderTuple[]): string[] {
+  const flat: string[] = new Array(tuples.length * 2);
+  for (let i = 0; i < tuples.length; i += 1) {
+    const tuple = tuples[i] as HeaderTuple;
+    flat[i * 2] = tuple[0];
+    flat[i * 2 + 1] = tuple[1];
+  }
+  return flat;
 }
 
 function releaseNativeBody(handle: NativeBodyHandle): void {
@@ -835,9 +887,10 @@ export class Response {
   private readonly payload: NativeResponse;
   private readonly requestUrl: string;
   private redirectedMemo: boolean | undefined;
-  private readonly headersInit: HeaderTuple[];
+  private readonly headersInit: readonly string[];
   private headersInstance: Headers | null;
-  private readonly cookiesInit: HeaderTuple[];
+  private readonly cookiesInit: readonly string[] | undefined;
+  private readonly bodyHandleId: number | null;
   private cookiesRecord: Record<string, string | string[]> | null;
   private inlineBody: Buffer | null;
   private bodySource: ReadableStream<Uint8Array> | null;
@@ -859,6 +912,7 @@ export class Response {
     this.cookiesRecord = null;
     this.contentLength = this.payload.contentLength ?? null;
     this.inlineBody = this.payload.bodyBytes ?? null;
+    this.bodyHandleId = this.payload.bodyHandle ?? null;
     this.nativeHandle = null;
 
     if (typeof bodySource !== "undefined") {
@@ -869,11 +923,11 @@ export class Response {
       // Inline body provided by native layer
       this.bodySource = null;
       this.nativeHandleAvailable = false;
-    } else if (this.payload.bodyHandle !== null) {
+    } else if (this.bodyHandleId !== null) {
       // Defer stream creation - we might use fast path instead
       this.bodySource = null;
       this.nativeHandleAvailable = true;
-      this.nativeHandle = { id: this.payload.bodyHandle, released: false };
+      this.nativeHandle = { id: this.bodyHandleId, released: false };
       bodyHandleFinalizer?.register(this, this.nativeHandle, this.nativeHandle);
     } else {
       this.bodySource = null;
@@ -904,7 +958,7 @@ export class Response {
 
   get headers(): Headers {
     if (!this.headersInstance) {
-      this.headersInstance = new Headers(this.headersInit);
+      this.headersInstance = new Headers(headerTuplesFromFlat(this.headersInit));
     }
     return this.headersInstance;
   }
@@ -912,7 +966,10 @@ export class Response {
   get cookies(): Record<string, string | string[]> {
     if (!this.cookiesRecord) {
       const record: Record<string, string | string[]> = Object.create(null);
-      for (const [name, value] of this.cookiesInit) {
+      const flat = this.cookiesInit ?? [];
+      for (let i = 0; i + 1 < flat.length; i += 2) {
+        const name = flat[i] as string;
+        const value = flat[i + 1] as string;
         const existing = record[name];
         if (existing === undefined) {
           record[name] = value;
@@ -940,16 +997,16 @@ export class Response {
       });
     }
 
-    if (this.inlineBody === null && this.payload.bodyHandle === null && this.bodySource === null) {
+    if (this.inlineBody === null && this.bodyHandleId === null && this.bodySource === null) {
       return null;
     }
 
     // Lazily create the stream if needed (disables fast path)
-    if (this.bodySource === null && this.nativeHandleAvailable && this.payload.bodyHandle !== null) {
+    if (this.bodySource === null && this.nativeHandleAvailable && this.bodyHandleId !== null) {
       if (this.nativeHandle) {
         bodyHandleFinalizer?.unregister(this.nativeHandle);
       }
-      const handle = this.nativeHandle ?? { id: this.payload.bodyHandle, released: false };
+      const handle = this.nativeHandle ?? { id: this.bodyHandleId, released: false };
       this.nativeHandle = handle;
       this.bodySource = createNativeBodyStream(handle);
       this.nativeHandleAvailable = false;
@@ -1036,11 +1093,11 @@ export class Response {
     }
 
     // If we still have the native handle (fast path), we need to create the stream first
-    if (this.nativeHandleAvailable && this.payload.bodyHandle !== null) {
+    if (this.nativeHandleAvailable && this.bodyHandleId !== null) {
       if (this.nativeHandle) {
         bodyHandleFinalizer?.unregister(this.nativeHandle);
       }
-      const handle = this.nativeHandle ?? { id: this.payload.bodyHandle, released: false };
+      const handle = this.nativeHandle ?? { id: this.bodyHandleId, released: false };
       this.nativeHandle = handle;
       this.bodySource = createNativeBodyStream(handle);
       this.nativeHandleAvailable = false;
@@ -1076,10 +1133,10 @@ export class Response {
     }
 
     // Fast path: if native handle is still available, read entire body in one Rust call
-    if (this.nativeHandleAvailable && this.payload.bodyHandle !== null) {
+    if (this.nativeHandleAvailable && this.bodyHandleId !== null) {
       this.nativeHandleAvailable = false;
       try {
-        return await nativeBinding.readBodyAll(this.payload.bodyHandle);
+        return await nativeBinding.readBodyAll(this.bodyHandleId);
       } catch (error) {
         // Handle already consumed or error
         if (String(error).includes("Body handle") && String(error).includes("not found")) {
@@ -2535,6 +2592,53 @@ function applyNativeEmulationMode(
   }
 }
 
+function callNativeRequest(
+  options: NativeRequestOptions,
+  requestId: number,
+  cancellable: boolean,
+): Promise<NativeResponse> {
+  let flags = 0;
+  if (options.ephemeral) flags |= FLAG_EPHEMERAL;
+  if (options.disableDefaultHeaders) flags |= FLAG_DISABLE_DEFAULT_HEADERS;
+  if (options.insecure) flags |= FLAG_INSECURE;
+  if (options.compress === false) flags |= FLAG_NO_COMPRESS;
+  if (options.captureDiagnostics) flags |= FLAG_CAPTURE_DIAGNOSTICS;
+  if (cancellable) flags |= FLAG_CANCELLABLE;
+  if (options.redirect === "manual") flags |= FLAG_REDIRECT_MANUAL;
+  else if (options.redirect === "error") flags |= FLAG_REDIRECT_ERROR;
+
+  let extras: NativeRequestExtras | undefined;
+  if (
+    options.browser !== undefined ||
+    options.os !== undefined ||
+    options.emulationJson !== undefined ||
+    options.proxy !== undefined ||
+    options.trustStore !== undefined ||
+    options.onRequestEvent !== undefined
+  ) {
+    extras = {};
+    if (options.browser !== undefined) extras.browser = options.browser;
+    if (options.os !== undefined) extras.os = options.os;
+    if (options.emulationJson !== undefined) extras.emulationJson = options.emulationJson;
+    if (options.proxy !== undefined) extras.proxy = options.proxy;
+    if (options.trustStore !== undefined) extras.trustStore = options.trustStore;
+    if (options.onRequestEvent !== undefined) extras.onRequestEvent = options.onRequestEvent;
+  }
+
+  return nativeBinding.request(
+    options.url,
+    options.method,
+    options.sessionId,
+    requestId,
+    flags,
+    options.timeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    options.headers ? flattenHeaderTuples(options.headers) : undefined,
+    options.body,
+    options.transportId,
+    extras,
+  );
+}
+
 async function dispatchRequest(
   options: NativeRequestOptions,
   requestUrl: string,
@@ -2546,7 +2650,7 @@ async function dispatchRequest(
     let payload: NativeResponse;
 
     try {
-      payload = (await nativeBinding.request(options, requestId, false)) as NativeResponse;
+      payload = await callNativeRequest(options, requestId, false);
     } catch (error) {
       if (error instanceof RequestError) {
         throw error;
@@ -2570,7 +2674,7 @@ async function dispatchRequest(
   // (impossible here since we checked `!signal` above). Cast is safe; avoids non-null assertion lint.
   const abortHandler = setupAbort(signal, cancelNative) as AbortHandler;
 
-  const pending = Promise.race([nativeBinding.request(options, requestId, true), abortHandler.promise]);
+  const pending = Promise.race([callNativeRequest(options, requestId, true), abortHandler.promise]);
 
   let payload: NativeResponse;
 

--- a/src/wreq-js.ts
+++ b/src/wreq-js.ts
@@ -825,9 +825,11 @@ function markNativeBodyReleased(handle: NativeBodyHandle): void {
   bodyHandleFinalizer?.unregister(handle);
 }
 
-function createNativeBodyStream(handle: NativeBodyHandle): ReadableStream<Uint8Array> {
+function createNativeBodyStream(handle: NativeBodyHandle, onFirstUse?: () => void): ReadableStream<Uint8Array> {
   const stream = new ReadableStream<Uint8Array>({
     async pull(controller) {
+      onFirstUse?.();
+      onFirstUse = undefined;
       try {
         const chunk = await nativeBinding.readBodyChunk(handle.id);
 
@@ -1023,7 +1025,15 @@ export class Response {
       }
       const handle = this.nativeHandle ?? { id: this.bodyHandleId, released: false };
       this.nativeHandle = handle;
-      this.bodySource = createNativeBodyStream(handle);
+      // Native streams can mark first use directly, without a forwarding stream.
+      const source = createNativeBodyStream(handle, () => {
+        // clone() may have replaced this source with a tee branch before the pull.
+        if (this.bodySource === source) {
+          this.bodyUsed = true;
+        }
+      });
+      this.bodySource = source;
+      this.bodyStream = source;
       this.nativeHandleAvailable = false;
     }
 


### PR DESCRIPTION
Repeated `sessionId` requests rebuilt clients and trust stores, fragmented responses crossed N-API once per frame, and abandoned small bodies discarded reusable connections. This PR caches and pools that work, inlines already-received bodies, coalesces streamed reads with bounded buffering, and uses external Node buffers for bodies/chunks ≥256 KiB. It also fixes session/transport lifetime cleanup and preserves TLS isolation for default fetches.

## Measured benefit of each change

| Change | Net benefit and tradeoff in the measured workloads |
|---|---|
| Cache TLS trust stores (`91cc67c`) | **24.5× string-sessionId HTTP throughput**, 49.4× transport create/close throughput. Benefits repeated client construction; isolated HTTP is unchanged. |
| Pool string-sessionId clients (`540ae2d`) | **Another +90% HTTP / +823% HTTPS throughput** through client and connection reuse. Existing explicit Session throughput stays neutral. |
| Inline already-arrived unknown-length bodies (`28459b2`, `83f2c92`) | **+16–19% fast chunked/gzip throughput**. The final implementation preserves this gain while removing the initial 10 ms wait, which added ~11 ms to delayed-header latency. Late/large bodies still stream. |
| Preserve session jars and finalize sessions (`439bfe2`) | Fixes silent cookie loss after idle expiry and releases collected native state. Throughput is neutral; this is a correctness/lifetime win. |
| Positional N-API options and flat headers (`60c53cc`) | **~4% less client CPU per small request**, with **~1% lower throughput**. An efficiency tradeoff. |
| Bounded streaming pump and coalescing (`6c7bd5f`) | **4.1× fragmented-stream throughput**, but continuous 8 MiB streaming/full-body reads are **4–5% slower**. Fragmented-stream RSS can rise. Follow-up bypass/permit experiments did not help and are not included. |
| External Node buffers (`a196e02`) | **+4.4% at 1 MiB / +9.2% at 8 MiB** for full-body reads. Equal-rate tests show no meaningful large-body RSS penalty at 1 or 4 GiB/s. Small buffers have a memory tradeoff, addressed by the final cutoff below. Bun keeps copies by default and is effectively neutral. |
| Finalize collected transports (`a9c8118`) | Releases native clients and pooled connections from unclosed, collected transports. Throughput is neutral; a lifetime win. |
| Drain small abandoned remainders (`8206720`) | **+9.5% cancellation throughput**, **93% fewer new connections** per bounded sample. Normal reads are unchanged; large remainders still drop the connection. |
| Prevent isolated TLS resumption (`da073f1`) | Restores isolation between default fetch calls. **Isolated HTTPS is 38% slower** because resumption is disabled; explicit sessions are unchanged. An intentional correctness cost. |
| Raise external-buffer cutoff to 256 KiB (`a4b4be6`) | At equal load, **64 KiB peak RSS falls 262 → 198 MiB (−25%)**, and streamed 8 MiB RSS falls 201 → 186 MiB (−7%). Clean candidate throughput: 64 KiB **+0.03%**, 8 MiB stream **−1.14%**, both intervals include zero. Equal-rate CPU/request increases ~1.8% / ~2.8%, respectively. Large full-body external paths are retained. |
| Remove redundant native-body forwarding stream (`2697cbb`) | **Bun 8 MiB streaming +1.96%** (95% CI +0.68% to +3.27%). Node +0.63%, interval includes zero. Small requests, full-body reads, and fragmented streams remain within noise. First-use tracking stays on the native stream; cloned/arbitrary sources retain the forwarding wrapper. |
| Skip zero-fill before copying response bytes (`4291cd1`) | Incrementally over the stream change: **Bun 8 MiB streaming +3.82%** (CI +3.15% to +4.50%), **8 MiB full-body +1.62%** (CI +0.66% to +2.60%); **Node streaming +1.97%** (CI +1.26% to +2.70%). Node full-body reads already use external buffers and stay neutral. 64 KiB and fragmented cases remain within noise. Every copied byte is initialized before exposure to JS; external-buffer policy is unchanged. |
| Coalesce cold setup for isolated fetch (`b2250f2`) | For 16 concurrent first calls, **client CPU falls ~68–78%**, cold HTTP batches finish **10–12% sooner**, and verified HTTPS batches **4–7% sooner** on Node/Bun. One cold request and warmed throughput remain within noise. Only identical client configuration/trust-root construction is deduplicated; cookies, connections, browser profiles, and TLS resumption isolation are preserved. |

The 64 KiB memory cost has a concrete cause: external buffers retain **1.8× payload length in Rust Vec capacity** on average, versus 1× for 8 MiB full bodies. Tracked native allocations return to zero after forced GC, while allocator-retained RSS can remain high.

## Evidence and limits


Apple M4 Pro / Node 24.19.0, separate loopback HTTP/1.1/HTTPS server, release builds. Historical commits are compared with their immediate parents using six alternating pairs; ambiguous cases use ten longer pairs. Follow-up thresholds/pump variants use six rounds, including concurrency-1 checks. Memory runs hold request counts and rates equal for 20 seconds.

These are workload-specific benefits, not a universal net score. Parent deltas cannot be added or multiplied. Connection-heavy comparisons use capped batches to avoid macOS port exhaustion. Intervals use paired log throughput ratios and Student t critical values. HTTP/2, WAN, and other-platform performance are not established.

Before the final threshold adjustment, the complete 11-commit stack versus `74b92fe` measured **50.6× string-sessionId HTTP**, **+13.7% chunked**, **+19.8% gzip**, **4.1× fragmented streams**, and **+62.5% cancellation throughput**. Pooled small requests were ~1% slower and continuous 8 MiB streams ~3.4% slower. The threshold-only candidate was separately checked against `da073f1`; the full matrix has not been rerun with that last adjustment.

## Bun and native profiling follow-up

Bun 1.4.2 built-in CPU profiles and macOS native stack sampling of the release Rust addon identified a redundant JS forwarding stream and Neon's zero-fill immediately before copying response bytes. Post-change profiles no longer contain the forwarding pull on native streams, and zero-fill disappears from the native full-body hot-stack summary. Remaining costs include buffer copies, N-API calls, and socket/runtime work; sample percentages are not throughput gains.

Each new change was measured separately, with six alternating before/after pairs per runtime/workload, fresh client and separate server processes, 200 ms warm-up, 1.5 s measurement, and concurrency 16. All 192 new measured runs completed without errors. These are local HTTP/1.1 results; combined gains are not inferred by adding separate percentages. Profilers and builds did not overlap throughput measurements. Reports and raw samples are kept outside the PR.

## Isolated-fetch setup and identity checks

Bare fetch retains its independent-connection policy. Trust-root insertion and ephemeral client construction now coalesce concurrent cache misses, avoiding duplicate cold builds. Eight alternating pairs per runtime/protocol/burst shape measured cold batches; six paired warmed controls per runtime/protocol found no statistically clear sustained throughput regression. The HTTPS fixture uses a configured CA with verification enabled. These 240 new client runs completed without errors; this change does not claim the ~10× HTTPS gain associated with connection reuse.

A new HTTP/2 test verifies two 16-request bursts use 32 distinct connections, never resume TLS, and do not carry cookies or authorization headers between calls. A Rust concurrency test checks matching configurations share one build and different configurations remain separate. Docs clarify that a shared Transport permits connection-level linkage and that isolation does not conceal caller IPs or caller-supplied identifiers.

## Validation

- `npm run build`
- `npm test`: 223 tests passed locally on Node 20 and 24; the prior 222-test head also passed with external buffers disabled on Node 24
- Streaming checks verify the full byte sequence for paced, buffered, and 4 MiB bodies without assuming one read per server write.
- Bun integration checks cover native streaming, clone-after-body-access, and every byte of 64 KiB / 1 MiB / 8 MiB full-body responses.
- All 19 Rust unit tests passed; Bun client passed the 32-connection HTTP/2 isolation check against a separate Node server.
- `npm run typecheck`
- `npm run check`
- [CI passed on the final head](https://github.com/sqdshguy/wreq-js/actions/runs/33988176220): Linux Node 20/24/26, macOS Node 24, both native builds, TypeScript build, and lint.
- Initial benchmark: 808 recorded client runs, zero errors.
- Follow-up: 252 throughput runs and 34 equal-rate runs (2,176,000 measured requests), zero errors.

Draft for review; package versions are unchanged.

